### PR TITLE
Break out configuration/requires for indexers into `settings.rb`

### DIFF
--- a/umich_catalog_indexing/bin/mindex_hathi
+++ b/umich_catalog_indexing/bin/mindex_hathi
@@ -32,7 +32,8 @@ ls -l scratch
 #run index the file
 cmd="bundle exec traject 
   -c $TDIR/readers/$READER.rb 
-  -c $TDIR/writers/$WRITER.rb 
+  -c $TDIR/writers/$WRITER.rb
+  -c $TDIR/indexers/settings.rb
   -c $TDIR/indexers/common.rb 
   -c $TDIR/indexers/common_ht.rb
   -c $TDIR/indexers/subject_topic.rb

--- a/umich_catalog_indexing/bin/mindex_xml
+++ b/umich_catalog_indexing/bin/mindex_xml
@@ -43,7 +43,8 @@ echo $output
 #run index the file
 cmd="bundle exec traject 
   -c $TDIR/readers/$READER.rb 
-  -c $TDIR/writers/$WRITER.rb 
+  -c $TDIR/writers/$WRITER.rb
+  -c $TDIR/indexers/settings.rb
   -c $TDIR/indexers/common.rb 
   -c $TDIR/indexers/common_ht.rb
   -c $TDIR/indexers/subject_topic.rb

--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -1,47 +1,6 @@
 $:.unshift "#{File.dirname(__FILE__)}/../lib"
 
 
-require 'set'
-
-require 'library_stdnums'
-
-require 'traject/macros/marc21_semantics'
-extend Traject::Macros::Marc21Semantics
-
-require 'traject/macros/marc_format_classifier'
-extend Traject::Macros::MarcFormats
-
-require 'ht_traject'
-extend HathiTrust::Traject::Macros
-extend Traject::UMichFormat::Macros
-
-require 'marc/fastxmlwriter'
-
-require 'marc_record_speed_monkeypatch'
-require 'marc4j_fix'
-
-UmichOverlap = if ENV['NODB']
-                 require "ht_traject/no_db_mocks/ht_overlap"
-                 HathiTrust::NoDB::UmichOverlap
-               else
-                 require 'ht_traject/ht_overlap.rb'
-                 HathiTrust::UmichOverlap
-               end
-
-settings do
-  store "log.batch_progress", 10_000
-end
-
-
-logger.info RUBY_DESCRIPTION
-
-################################
-###### Setup ###################
-################################
-
-# Set up an area in the clipboard for use storing intermediate stuff
-each_record HathiTrust::Traject::Macros.setup
-
 #######  COMMON STUFF BETWEEN UMICH AND HT ########
 #######  INDEXING                          ########
 

--- a/umich_catalog_indexing/indexers/settings.rb
+++ b/umich_catalog_indexing/indexers/settings.rb
@@ -1,0 +1,42 @@
+$:.unshift "#{File.dirname(__FILE__)}/../lib"
+require 'set'
+
+require 'library_stdnums'
+
+require 'traject/macros/marc21_semantics'
+extend Traject::Macros::Marc21Semantics
+
+require 'traject/macros/marc_format_classifier'
+extend Traject::Macros::MarcFormats
+
+require 'ht_traject'
+extend HathiTrust::Traject::Macros
+extend Traject::UMichFormat::Macros
+
+require 'marc/fastxmlwriter'
+
+require 'marc_record_speed_monkeypatch'
+require 'marc4j_fix'
+
+UmichOverlap = if ENV['NODB']
+                 require "ht_traject/no_db_mocks/ht_overlap"
+                 HathiTrust::NoDB::UmichOverlap
+               else
+                 require 'ht_traject/ht_overlap.rb'
+                 HathiTrust::UmichOverlap
+               end
+
+settings do
+  store "log.batch_progress", 10_000
+end
+
+
+logger.info RUBY_DESCRIPTION
+
+################################
+###### Setup ###################
+################################
+
+# Set up an area in the clipboard for use storing intermediate stuff
+each_record HathiTrust::Traject::Macros.setup
+


### PR DESCRIPTION
Currently, test-running subsets of the indexers is a pain because
all the configuration, `require` statements, `extend`/`include`
of macros, etc. is at the top of `commong.rb`.

This simply moves all that stuff from the top of `common.rb`
into its own file, `settings.rb`, and adds that new file
to the `mindex_*` scripts.