### PR TITLE
Add author_authoritative to drive author_browse

### DIFF
--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -502,6 +502,17 @@
         </analyzer>
     </fieldType>
 
+
+    <!-- An even less aggressive exactish, primarily for browse matching -->
+    <fieldType name="browse_match" class="solr.TextField" positionIncrmentGap="&pig;">
+        <analyzer>
+            &less_aggressive_pre_tokenization_character_substitution;
+            &tokenize_into_one_big_token;
+            &trim_leading_and_trailing_whitespace;
+            &icu_case_folding_and_normalization;
+        </analyzer>
+    </fieldType>
+
     <fieldType name="lc_subject" class="solr.TextField"
                positionIncrementGap="&pig;">
         <analyzer>

--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -509,6 +509,9 @@
             &less_aggressive_pre_tokenization_character_substitution;
             &tokenize_into_one_big_token;
             &trim_leading_and_trailing_whitespace;
+            <filter class="solr.PatternReplaceFilterFactory"
+                    pattern="[;,.]+$" replacement=" " replace="all"
+            />
             &icu_case_folding_and_normalization;
         </analyzer>
     </fieldType>

--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -504,7 +504,7 @@
 
 
     <!-- An even less aggressive exactish, primarily for browse matching -->
-    <fieldType name="browse_match" class="solr.TextField" positionIncrmentGap="&pig;">
+    <fieldType name="browse_match" class="solr.TextField" positionIncrementGap="&pig;">
         <analyzer>
             &less_aggressive_pre_tokenization_character_substitution;
             &tokenize_into_one_big_token;

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -130,7 +130,8 @@
 <field name="related_title" type="text_no_stem_or_synonyms" indexed="true" stored="true"   multiValued="true" />
 <copyField source="author" dest="authorStr"/>
 
-<field name="author_authoritative" type="text_no_stem_or_synonyms" indexed="true" stored="true" multiValued="true"/>
+<field name="author_authoritative" type="browse_match" indexed="true" stored="true" multiValued="true" docValues="true"/>
+<copyField source="author" dest="author_authoritative"/>
 
 <!-- Mixed title/author -->
 

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -130,7 +130,7 @@
 <field name="related_title" type="text_no_stem_or_synonyms" indexed="true" stored="true"   multiValued="true" />
 <copyField source="author" dest="authorStr"/>
 
-<field name="author_authoritative" type="browse_match" indexed="true" stored="true" multiValued="true" docValues="true"/>
+<field name="author_authoritative" type="browse_match" indexed="true" stored="true" multiValued="true"/>
 <copyField source="author" dest="author_authoritative"/>
 
 <!-- Mixed title/author -->

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -131,7 +131,6 @@
 <copyField source="author" dest="authorStr"/>
 
 <field name="author_authoritative" type="browse_match" indexed="true" stored="true" multiValued="true"/>
-<copyField source="author" dest="author_authoritative"/>
 
 <!-- Mixed title/author -->
 

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -130,6 +130,8 @@
 <field name="related_title" type="text_no_stem_or_synonyms" indexed="true" stored="true"   multiValued="true" />
 <copyField source="author" dest="authorStr"/>
 
+<field name="author_authoritative" type="text_no_stem_or_synonyms" indexed="true" stored="true" multiValued="true"/>
+
 <!-- Mixed title/author -->
 
 <field name="title_author" type="text" indexed="true" stored="false" multiValued="true"/>

--- a/biblio/core.properties
+++ b/biblio/core.properties
@@ -1,5 +1,1 @@
-#Written by CorePropertiesLocator
-#Mon May 16 21:00:20 UTC 2022
-name=authors_only
-config=solrconfig.xml
-dataDir=/l/search-prep/solrs_and_data/core_data/biblio-authors_only/data
+name=biblio

--- a/biblio/core.properties
+++ b/biblio/core.properties
@@ -1,1 +1,5 @@
-name=biblio
+#Written by CorePropertiesLocator
+#Mon May 16 21:00:20 UTC 2022
+name=authors_only
+config=solrconfig.xml
+dataDir=/l/search-prep/solrs_and_data/core_data/biblio-authors_only/data

--- a/umich_catalog_indexing/Gemfile.lock
+++ b/umich_catalog_indexing/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
 
 PLATFORMS
   universal-java-1.8
+  universal-java-11
 
 DEPENDENCIES
   alma_rest_client!
@@ -204,4 +205,4 @@ DEPENDENCIES
   yell (~> 2.0)
 
 BUNDLED WITH
-   2.3.10
+   2.3.13

--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -132,6 +132,26 @@ to_field "author_top", extract_marc_unless("100abcdefgjklnpqtu0:110abcdefgklnptu
 to_field "author_rest", extract_marc("505r")
 
 
+#### "Authoritative" authors from the 100/110/111 and 700/710/711
+#### Based on communication with Leigh Billings
+# 100: abc*dj*q
+# 110: ab*c*d*
+# 111:ac*d*e*n*
+#
+# It looks essentially like what we've got for author except the subfields are different. Probably
+# a better idea to just change the author definition based on this new information?
+
+aa_00 = "abcdjq" # currently missing j
+aa_01 = "abcd"   # currently the same
+aa_11 = "acden"  # currently addded b, missing e,n
+
+to_field "author_authoritative", extract_marc_unless(%w[
+  100#{aa_00}:700#{aa_00}
+  110:#{aa_10}:710#{aa_10}
+  111#{aa_11}:711#{aa_11}
+], skipWaSeSS)
+
+
 # Naconormalizer for author, only under jruby
 
 if defined? JRUBY_VERSION

--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -117,6 +117,14 @@ to_field 'barcode', extract_marc('974a')
 ######### AUTHOR FIELDS ########
 ################################
 
+# Naconormalizer for author, only under jruby
+if defined? JRUBY_VERSION
+  require 'naconormalizer'
+  author_normalizer = NacoNormalizer.new
+else
+  author_normalizer = nil
+end
+
 # We need to skip all the 710 with a $9 == 'WaSeSS'
 
 skipWaSeSS = ->(rec, field) { field.tag == '710' and field['9'] =~ /WaSeSS/ }
@@ -131,16 +139,6 @@ to_field 'author2', extract_marc_unless("110ab:111ab:700abcd:710ab:711ab", skipW
 to_field "author_top", extract_marc_unless("100abcdefgjklnpqtu0:110abcdefgklnptu04:111acdefgjklnpqtu04:700abcdejqux034:710abcdeux034:711acdegjnqux034:720a:765a:767a:770a:772a:774a:775a:776a:777a:780a:785a:786a:787a:245c", skipWaSeSS)
 to_field "author_rest", extract_marc("505r")
 
-# Naconormalizer for author, only under jruby
-
-if defined? JRUBY_VERSION
-  require 'naconormalizer'
-  author_normalizer = NacoNormalizer.new
-else
-  author_normalizer = nil
-end
-
-
 to_field "authorSort", extract_marc_unless("100abcd:110abcd:111abc:110ab:700abcd:710ab:711ab", skipWaSeSS, :first => true) do |rec, acc, context|
   if author_normalizer
     acc.map! { |a| author_normalizer.normalize(a) }
@@ -148,10 +146,18 @@ to_field "authorSort", extract_marc_unless("100abcd:110abcd:111abc:110ab:700abcd
   acc.compact!
 end
 
+# For browse entries, we only want teh 100/110/111 and the 7xx counterparts _if_ the 7xx
+# has second-indicator 2 ("authoritative")
+# TODO: Figure out if forcing ind2=2 is too restrictive
+to_field 'author_authoritative', extract_marc_unless(
+  "100abcdjq:110abcd:111acden:700|*2|abcdjq:710|*2|abcd:711|*2|acden",
+skipWaSeSS)
+
 #changes by mrio Feb 2022
 to_field "main_author_display", extract_marc("100abcdefgjklnpqtu4:101abcdefgjklnpqtu4:110abcdefgjklnpqtu4:111abcdefgjklnpqtu4")
 to_field "main_author", extract_marc("100abcdgjkqu:101abcdgjkqu:110abcdgjkqu:111abcdgjkqu")
 
+# TODO: Change traject to allow, e.g., 700|*[^ ]abc where brackets indicate a regex
 skip_non_space_indicator_2 = ->(rec, field) { field.indicator2 != " " }
 skip_analytical_entry_or_title = ->(rec, field) { field.indicator2 == "2" || !field["t"].nil? }
 skip_analytical_entry_or_no_title = ->(rec, field) { field.indicator2 == "2" || field["t"].nil? }

--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -126,31 +126,10 @@ to_field 'mainauthor_role', extract_marc('100e:110e:111e', :trim_punctuation => 
 to_field 'mainauthor_role', extract_marc('1004:1104:1114', :translation_map => "ht/relators")
 
 
-to_field 'author', extract_marc_unless("100abcdq:110abcd:111abc:700abcdq:710abcd:711abc", skipWaSeSS)
+to_field 'author', extract_marc_unless("100abcdjq:110abcd:111acden:700abcdjq:710abcd:711acden", skipWaSeSS)
 to_field 'author2', extract_marc_unless("110ab:111ab:700abcd:710ab:711ab", skipWaSeSS)
 to_field "author_top", extract_marc_unless("100abcdefgjklnpqtu0:110abcdefgklnptu04:111acdefgjklnpqtu04:700abcdejqux034:710abcdeux034:711acdegjnqux034:720a:765a:767a:770a:772a:774a:775a:776a:777a:780a:785a:786a:787a:245c", skipWaSeSS)
 to_field "author_rest", extract_marc("505r")
-
-
-#### "Authoritative" authors from the 100/110/111 and 700/710/711
-#### Based on communication with Leigh Billings
-# 100: abc*dj*q
-# 110: ab*c*d*
-# 111:ac*d*e*n*
-#
-# It looks essentially like what we've got for author except the subfields are different. Probably
-# a better idea to just change the author definition based on this new information?
-
-aa_00 = "abcdjq" # currently missing j
-aa_01 = "abcd"   # currently the same
-aa_11 = "acden"  # currently addded b, missing e,n
-
-to_field "author_authoritative", extract_marc_unless(%w[
-  100#{aa_00}:700#{aa_00}
-  110:#{aa_10}:710#{aa_10}
-  111#{aa_11}:711#{aa_11}
-], skipWaSeSS)
-
 
 # Naconormalizer for author, only under jruby
 


### PR DESCRIPTION
Adds new `author_authoritative` to drive browse.

Right now, the definition of `author` is very close to this, The subfields used in the new `to_field` are as dictated to me by Leigh Billings,  and I'm assuming (remembering?) that the selection of subfields in the current code was relatively arbitrary. 

We should pick one of the following:
  * merge this in
  * merge this in and later change the def of `author`
  * just change the def of `author`