### PR TITLE
Use a pushgateway for index job metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - HLB_XML_ENDPOINT=https://apps.lib.umich.edu/browse/categories/xml.php 
         #- JRUBY_OPTS=--debug
       - NODB=1
+      - PROMETHEUS_PUSH_GATEWAY=http://pushgateway:9091
     env_file:
       - ./umich_catalog_indexing/.env
       - ./umich_catalog_indexing/.env-dev-values
@@ -79,6 +80,11 @@ services:
       - 9090:9090
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  pushgateway:
+    image: prom/pushgateway
+    ports:
+      - 9091:9091
 
 volumes:
   gem_cache:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,6 +1,9 @@
 scrape_configs:
-- job_name: catalog_indexer
+- job_name: pushgateway
   honor_labels: true
   honor_timestamps: true
+  static_configs:
+    - targets: ['pushgateway:9091']
+- job_name: catalog_indexer
   static_configs:
     - targets: ['web:9394']

--- a/umich_catalog_indexing/Gemfile
+++ b/umich_catalog_indexing/Gemfile
@@ -9,8 +9,7 @@ group :development do
 end
 
 gem 'yell', '~>2.0'
-gem "yabeda-sidekiq"
-gem "yabeda-prometheus"
+gem 'prometheus-client', '~>4.0'
 
 gem 'rack' #for sidekiq
 gem 'traject', '~>3.0'

--- a/umich_catalog_indexing/Gemfile.lock
+++ b/umich_catalog_indexing/Gemfile.lock
@@ -33,8 +33,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    anyway_config (2.3.0)
-      ruby-next-core (>= 0.14.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
@@ -45,7 +43,6 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
-    dry-initializer (3.0.4)
     ffi (1.15.5-java)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -90,7 +87,7 @@ GEM
     naconormalizer (1.0.1-java)
     nokogiri (1.13.4-java)
       racc (~> 1.4)
-    prometheus-client (2.1.0)
+    prometheus-client (4.0.0)
     pry (0.14.1-java)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -120,7 +117,6 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-debug-base (0.11.0-java)
-    ruby-next-core (0.15.1)
     scrub_rb (1.0.1)
     sequel (5.55.0)
     sidekiq (6.4.2)
@@ -151,18 +147,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yabeda (0.11.0)
-      anyway_config (>= 1.0, < 3)
-      concurrent-ruby
-      dry-initializer
-    yabeda-prometheus (0.8.0)
-      prometheus-client (>= 0.10, < 3.0)
-      rack
-      yabeda (~> 0.10)
-    yabeda-sidekiq (0.8.1)
-      anyway_config (>= 1.3, < 3)
-      sidekiq
-      yabeda (~> 0.6)
     yell (2.2.2)
     zeitwerk (2.5.4)
 
@@ -181,6 +165,7 @@ DEPENDENCIES
   match_map (~> 3.0)
   mysql2
   naconormalizer
+  prometheus-client (~> 4.0)
   pry
   pry-debugger-jruby
   psych
@@ -193,9 +178,7 @@ DEPENDENCIES
   traject-marc4j_reader (~> 1.0)
   traject_umich_format!
   webmock (~> 3.0)
-  yabeda-prometheus
-  yabeda-sidekiq
   yell (~> 2.0)
 
 BUNDLED WITH
-   2.3.10
+   2.3.13

--- a/umich_catalog_indexing/lib/sidekiq_jobs.rb
+++ b/umich_catalog_indexing/lib/sidekiq_jobs.rb
@@ -1,38 +1,78 @@
 require "sidekiq"
-require "yabeda/sidekiq"
-require "yabeda/prometheus"
+require "prometheus/client"
+require "prometheus/client/push"
+require "prometheus/client/registry"
 require "/app/lib/jobs"
 
-Yabeda.configure do
-  gauge :indexing_job_last_success, comment: "Time the indexing last succeeded", tags: [:destination, :type]
-end
-Yabeda.configure!
+class CatalogIndexMetrics
+  def initialize(labels)
+    @labels = labels
+    @start_time = current_timestamp
+  end
 
-Sidekiq.configure_server do |_config|
-  Yabeda::Prometheus::Exporter.start_metrics_server!
+  def push
+    indexing_job_duration_seconds.set(current_timestamp - @start_time)
+    indexing_job_last_success.set(current_timestamp)
+    gateway.add(registry)
+  end
+
+  private
+
+  def current_timestamp
+    Time.now.to_i
+  end
+
+  def registry
+    @registry ||= Prometheus::Client::Registry.new
+  end
+
+  def gateway
+    @gateway ||= Prometheus::Client::Push.new(
+      job: "catalog_index",
+      gateway: ENV.fetch("PROMETHEUS_PUSH_GATEWAY"),
+      grouping_key: @labels
+    )
+  end
+
+  def indexing_job_last_success
+    @indexing_job_last_success ||= registry.gauge(
+      :indexing_job_last_success,
+      docstring: "Last successful run of an indexing job"
+    )
+  end
+
+  def indexing_job_duration_seconds
+    @indexing_job_duration_seconds = registry.gauge(
+      :indexing_job_duration_seconds,
+      docstring: "Time spent running an indexing job"
+    )
+  end
 end
 
 class IndexIt
   include Sidekiq::Worker
   def perform(file, solr_url)
     puts "indexing #{file} into #{solr_url}"
+    metrics = CatalogIndexMetrics.new({ type: "IndexIt", destination: solr_url })
     Jobs::IndexAlmaXml.new(file: file, solr_url: solr_url).run
-    Yabeda.indexing_job_last_success.set({type: "IndexIt", destination: solr_url},Time.now.to_i) 
+    metrics.push
   end
 end
 class DeleteIt
   include Sidekiq::Worker
   def perform(file, solr_url)
     puts "indexing deletes from #{file} into #{solr_url}"
+    metrics = CatalogIndexMetrics.new({ type: "DeleteIt", destination: solr_url })
     Jobs::DeleteAlmaIds.new(file: file, solr_url: solr_url).run
-    Yabeda.indexing_job_last_success.set({type: "DeleteIt", destination: solr_url},Time.now.to_i) 
+    metrics.push
   end
 end
 class IndexHathi
   include Sidekiq::Worker
   def perform(file, solr_url)
     puts "indexing zephir #{file} into #{solr_url}"
+    metrics = CatalogIndexMetrics.new({ type: "IndexHathi", destination: solr_url })
     Jobs::IndexHathiJson.new(file: file, solr_url: solr_url).run
-    Yabeda.indexing_job_last_success.set({type: "IndexHathi", destination: solr_url},Time.now.to_i) 
+    metrics.push
   end
 end


### PR DESCRIPTION
While sidekiq is itself an offline queue, we're interested in when
IndexIt ran versus when IndexHathi ran, and those specific jobs are
transient. When storing those metrics just in sidekiq, we had to deal
with the inconsistent numbers coming from different replicas, and each
replica would forget its past state on reboot.

This is exactly the sort of thing that the pushgateway was designed for,
but an offline queue (sidekiq) pushing metrics to a pushgateway was
exactly not the sort of thing that Yabeda was designed for. Yabeda saves
a lot of typing but assumes a field of metrics that will change over
time (e.g. number of requests, number of books checked out).

With cronjobs, pushing to a pushgateway works just fine, since the state
will disappear with the cronjob. With sidekiq, the state was persisting
between cronjobs, resulting in weird behavior, especially with multiple
replicas trying to override each other.

By using the prometheus client directly, we can init a new registry and
push metrics with different grouping keys so that nothing overrides
anything unexpected.