### PR TITLE
Build an image with records baked in

### DIFF
--- a/biblio/Dockerfile
+++ b/biblio/Dockerfile
@@ -4,3 +4,11 @@ ENV SOLR_PORT=8026
 
 COPY --chown=solr:solr . /var/solr/data/biblio
 COPY --chown=solr:solr ./examples /examples
+
+
+RUN start-local-solr \
+    && bash /examples/load_into_solr.sh \
+    && stop-local-solr \
+    && cp -r /var/solr/biblio /tmp
+
+CMD cp -r /tmp/biblio /var/solr && solr-foreground

--- a/biblio/Dockerfile
+++ b/biblio/Dockerfile
@@ -1,14 +1,34 @@
-FROM solr:8
+FROM solr:8 AS indexer
 
 ENV SOLR_PORT=8026
 
 COPY --chown=solr:solr . /var/solr/data/biblio
 COPY --chown=solr:solr ./examples /examples
 
+# The solr:8 Dockerfile includes
+#
+# VOLUME /var/solr 
+# https://github.com/docker-solr/docker-solr/blob/master/8.11/Dockerfile#L118
+# 
+#
+# Among other things, this means that anything we write to /var/solr/data
+# during a RUN command will be lost:
+# https://docs.docker.com/engine/reference/builder/#volume
+# (Things copied with COPY do appear to persist.)
+#
+# Using multi-stage builds allows us to build the data, storing it in
+# /tmp/biblio, and then copying from that temporary image into our final output
+# image.
 
-RUN start-local-solr \
-    && bash /examples/load_into_solr.sh \
-    && stop-local-solr \
-    && cp -r /var/solr/biblio /tmp
+RUN mkdir /tmp/biblio && \
+    ln -s /tmp/biblio /var/solr/biblio && \
+    start-local-solr && \
+    bash /examples/load_into_solr.sh && \
+    stop-local-solr
 
-CMD cp -r /tmp/biblio /var/solr && solr-foreground
+FROM solr:8
+
+ENV SOLR_PORT=8026
+
+COPY --chown=solr:solr . /var/solr/data/biblio
+COPY --from=indexer /tmp/biblio /var/solr/biblio

--- a/biblio/examples/load_into_solr.sh
+++ b/biblio/examples/load_into_solr.sh
@@ -1,7 +1,22 @@
+#!/bin/bash
+
+SOLR_URL="http://localhost:8026/solr/biblio"
 input="/examples/sample1.json"
+echo "Indexing records into Solr..."
+nrec=$(cat $input | wc -l)
+i=0
 while IFS= read -r line
 do
-cat << EOT | curl -X POST -H 'Content-Type:application/json'  --data-binary @- http://localhost:8026/solr/biblio/update/json?commit=true
-[$line]
-EOT
+  let i++
+  cat <<-EOT | curl -s -X POST -H "Content-Type:application/json"  --data-binary @- "$SOLR_URL/update/json/docs" > /dev/null
+  [$line]
+	EOT
+  if (( $i % 50 == 0 || $i == $nrec )); then
+    echo -ne "$i / $nrec records indexed\r"
+  fi
 done < "$input"
+echo 
+
+echo "Committing"
+curl -s -H "Content-Type: application/json" -X POST -d'{"commit": {}}' "$SOLR_URL/update?wt=json"
+echo "Done"


### PR DESCRIPTION
- Run indexing during docker image build process

- Faster indexing and progress reporting for records loaded

- Uses a multi-stage build to work around changes to `/var/solr` not persisting after `RUN` commands (because of https://github.com/docker-solr/docker-solr/blob/master/8.11/Dockerfile#L118)