### PR TITLE
Used fixed High Level Browse

### DIFF
--- a/umich_catalog_indexing/Gemfile
+++ b/umich_catalog_indexing/Gemfile
@@ -43,9 +43,7 @@ end
 
 gem 'marc-fastxmlwriter', '~>1.0'
 
-gem 'high_level_browse',
-  git: 'https://github.com/billdueber/high_level_browse', 
-  branch: 'nokogiri_not_oga'
+gem 'high_level_browse', '>=1.1'
 
 gem 'pry'
 

--- a/umich_catalog_indexing/Gemfile.lock
+++ b/umich_catalog_indexing/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/billdueber/high_level_browse
-  revision: 6af3ed8bfeb2022191b75f7d8900f470c68dbf7c
-  branch: nokogiri_not_oga
-  specs:
-    high_level_browse (0.2.0)
-      nokogiri (~> 1.0)
-
-GIT
   remote: https://github.com/mlibrary/alma_rest_client
   revision: 1d41c631573e4585562e06b43df025c2cdac99c6
   tag: 1.1.0
@@ -25,7 +17,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.5)
+    activesupport (6.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -52,12 +44,14 @@ GEM
       rake
     hashdiff (1.0.1)
     hashie (5.0.0)
-    http (5.0.4)
+    high_level_browse (1.1.0)
+      nokogiri (~> 1.0)
+    http (5.1.0)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.4.0)
-    http-cookie (1.0.4)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     httparty (0.20.0)
@@ -76,7 +70,7 @@ GEM
       rexml
       scrub_rb (>= 1.0.1, < 2)
       unf
-    marc-fastxmlwriter (1.0.0)
+    marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
     marc-marc4j (1.0.0-java)
       marc (~> 1)
@@ -85,10 +79,10 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.15.0)
+    minitest (5.16.0)
     multi_xml (0.6.0)
     naconormalizer (1.0.1-java)
-    nokogiri (1.13.4-java)
+    nokogiri (1.13.6-java)
       racc (~> 1.4)
     prometheus-client (2.1.0)
     pry (0.14.1-java)
@@ -98,11 +92,11 @@ GEM
     pry-debugger-jruby (2.1.0-java)
       pry (>= 0.13, < 0.15)
       ruby-debug-base (>= 0.10.4, < 0.12)
-    psych (4.0.3-java)
+    psych (4.0.4-java)
       jar-dependencies (>= 0.1.7)
     public_suffix (4.0.7)
     racc (1.6.0-java)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rake (13.0.6)
     redis (4.6.0)
     rexml (3.2.5)
@@ -122,8 +116,8 @@ GEM
     ruby-debug-base (0.11.0-java)
     ruby-next-core (0.15.1)
     scrub_rb (1.0.1)
-    sequel (5.55.0)
-    sidekiq (6.4.2)
+    sequel (5.57.0)
+    sidekiq (6.5.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -164,7 +158,7 @@ GEM
       sidekiq
       yabeda (~> 0.6)
     yell (2.2.2)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 GEM
   remote: https://rubygems.pkg.github.com/mlibrary/
@@ -172,13 +166,13 @@ GEM
     sftp (0.2.0)
 
 PLATFORMS
-  universal-java-1.8
+  universal-java-11
 
 DEPENDENCIES
   alma_rest_client!
   bundler (~> 2.0)
   byebug
-  high_level_browse!
+  high_level_browse (>= 1.1)
   httpclient (~> 2.0)
   jdbc-mysql (~> 8.0)
   library_stdnums (~> 1.0)
@@ -204,4 +198,4 @@ DEPENDENCIES
   yell (~> 2.0)
 
 BUNDLED WITH
-   2.3.10
+   2.3.13


### PR DESCRIPTION
Somewhere along the line the format the HLB xml file provided
by umich changed (it used to include a `sub-topic` tag
and no longer does. HLB 1.0 was happily creating an
empty lookup table with the new XML format.

Update to use `high_level_browse` 1.1.1 or higher.
REQUIRES NEW GENERATION OF THE HLB LOOKUP TABLE
with, e.g., `bundle exec fetch_new_hlb <directory>`
which will put `hlb.json.gz` into that directory.