### PR TITLE
updated hlb gem

### DIFF
--- a/umich_catalog_indexing/Gemfile
+++ b/umich_catalog_indexing/Gemfile
@@ -43,9 +43,7 @@ end
 
 gem 'marc-fastxmlwriter', '~>1.0'
 
-gem 'high_level_browse',
-  git: 'https://github.com/billdueber/high_level_browse', 
-  branch: 'nokogiri_not_oga'
+gem 'high_level_browse', '>=1.1'
 
 gem 'pry'
 

--- a/umich_catalog_indexing/Gemfile.lock
+++ b/umich_catalog_indexing/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/billdueber/high_level_browse
-  revision: 6af3ed8bfeb2022191b75f7d8900f470c68dbf7c
-  branch: nokogiri_not_oga
-  specs:
-    high_level_browse (0.2.0)
-      nokogiri (~> 1.0)
-
-GIT
   remote: https://github.com/mlibrary/alma_rest_client
   revision: 1d41c631573e4585562e06b43df025c2cdac99c6
   tag: 1.1.0
@@ -52,6 +44,8 @@ GEM
       rake
     hashdiff (1.0.1)
     hashie (5.0.0)
+    high_level_browse (1.1.1)
+      nokogiri (~> 1.0)
     http (5.0.4)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -179,7 +173,7 @@ DEPENDENCIES
   alma_rest_client!
   bundler (~> 2.0)
   byebug
-  high_level_browse!
+  high_level_browse (>= 1.1)
   httpclient (~> 2.0)
   jdbc-mysql (~> 8.0)
   library_stdnums (~> 1.0)
@@ -205,4 +199,4 @@ DEPENDENCIES
   yell (~> 2.0)
 
 BUNDLED WITH
-   2.3.13
+   2.3.10


### PR DESCRIPTION
This is essentially the same PR as #16  I just didn't want to deal with the risk of rebasing. 

Here's the comment from @billdueber from that PR:

> Somewhere along the line the format the HLB xml file provided
> by umich changed (it used to include a sub-topic tag
> and no longer does. HLB 1.0 was happily creating an
> empty lookup table with the new XML format.
> 
> Update to use high_level_browse 1.1.1 or higher.
> REQUIRES NEW GENERATION OF THE HLB LOOKUP TABLE
> with, e.g., bundle exec fetch_new_hlb <directory>
> which will put hlb.json.gz into that directory.

I've tested the updated with the `dev_solr` set of records. hlb is indeed coming through properly now.
