### PR TITLE
Fix warning in jruby

### DIFF
--- a/mock-ht/Dockerfile
+++ b/mock-ht/Dockerfile
@@ -1,17 +1,17 @@
-FROM ruby:2.7.2
+FROM ruby:3.1
 
 LABEL maintainer="mrio@umich.edu"
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   apt-transport-https
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   nodejs \
   vim
 
-RUN gem install bundler:2.1.4
+RUN gem install bundler:2.3
 
 
 RUN mkdir -p /gems 

--- a/mock-ht/Gemfile
+++ b/mock-ht/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
-
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/mock-ht/Gemfile.lock
+++ b/mock-ht/Gemfile.lock
@@ -2,34 +2,31 @@ GEM
   remote: https://rubygems.org/
   specs:
     multi_json (1.15.0)
-    mustermann (1.1.1)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.3)
-    rack-protection (2.2.0)
+    rack (2.2.4)
+    rack-protection (2.2.2)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
+    sinatra (2.2.2)
+      mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.2.0)
+      rack-protection (= 2.2.2)
       tilt (~> 2.0)
-    sinatra-contrib (2.2.0)
+    sinatra-contrib (2.2.2)
       multi_json
-      mustermann (~> 1.0)
-      rack-protection (= 2.2.0)
-      sinatra (= 2.2.0)
+      mustermann (~> 2.0)
+      rack-protection (= 2.2.2)
+      sinatra (= 2.2.2)
       tilt (~> 2.0)
-    tilt (2.0.10)
+    tilt (2.0.11)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   sinatra
   sinatra-contrib
 
-RUBY VERSION
-   ruby 2.7.2p137
-
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/umich_catalog_indexing/Dockerfile
+++ b/umich_catalog_indexing/Dockerfile
@@ -5,6 +5,7 @@ ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   build-essential\
+  netbase\
   libffi-dev \
   git \
   vim-tiny \

--- a/umich_catalog_indexing/Dockerfile.prod
+++ b/umich_catalog_indexing/Dockerfile.prod
@@ -5,6 +5,7 @@ ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   build-essential\
+  netbase\
   libffi-dev \
   git \
   vim-tiny \


### PR DESCRIPTION
Adds netbase; updates mock-ht dockerfile

* per https://github.com/jruby/jruby/issues/3955 adds netbase to get rid of this warning: `WARNING: Failed to load native protocols db`
* updates mock-ht Dockerfile because it was using an old verion of node and ruby