### PR TITLE
Fix author_authoritative browse field

### DIFF
--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -154,6 +154,11 @@
 '>
 
 
+<!ENTITY cleanup_whitespace '
+&trim_leading_and_trailing_whitespace;
+&collapse_whitespace;
+'>
+
 <!-- stemming -->
 <!-- Note we don't need to pull in the headwords, etc, for kstem since they're hardcoded (!) in.
      See the files at https://github.com/apache/lucene-solr/tree/master/lucene/analysis/common/src/java/org/apache/lucene/analysis/en
@@ -519,10 +524,8 @@
         <analyzer>
             &less_aggressive_pre_tokenization_character_substitution;
             &tokenize_into_one_big_token;
-            &trim_leading_and_trailing_whitespace;
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="[;,.]+$" replacement=" " replace="all"
-            />
+            &cleanup_whitespace;
+            &remove_unnecessary_ending_punctuation;
             &icu_case_folding_and_normalization;
         </analyzer>
     </fieldType>
@@ -567,8 +570,7 @@
         <analyzer>
             &tokenize_into_one_big_token;
             &normalize_numeric_digits;
-            &trim_leading_and_trailing_whitespace;
-            &collapse_whitespace;
+            &cleanup_whitespace;
             &remove_unnecessary_ending_punctuation;
         </analyzer>
     </fieldType>

--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -103,6 +103,11 @@
         replace="all"/>
 '>
 
+<!ENTITY collapse_spaces '
+<filter class="solr.PatternReplaceFilterFactory" pattern="&white;" replacement=" "
+        replace="all"/>
+'>
+
 <!ENTITY trim_leading_and_trailing_whitespace '
 <filter class="solr.TrimFilterFactory"/>
 '>
@@ -138,6 +143,7 @@
 
 <!ENTITY cleanup '
 <filter class="solr.PatternReplaceFilterFactory" pattern="[&control;]" replacement="" replace="all"/>
+&collapse_spaces;
 &trim_leading_whitespace_and_punctuation;
 &trim_trailing_whitespace_and_punctuation;
 '>

--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -108,6 +108,11 @@
         replace="all"/>
 '>
 
+<!ENTITY remove_unnecessary_ending_punctuation '
+<filter class="solr.PatternReplaceFilterFactory" pattern="[.;,]+$" replacement=""
+        replace="all"/>
+'>
+
 <!ENTITY trim_leading_and_trailing_whitespace '
 <filter class="solr.TrimFilterFactory"/>
 '>
@@ -562,7 +567,9 @@
         <analyzer>
             &tokenize_into_one_big_token;
             &normalize_numeric_digits;
-            &cleanup;
+            &trim_leading_and_trailing_whitespace;
+            &collapse_whitespace;
+            &remove_unnecessary_ending_punctuation;
         </analyzer>
     </fieldType>
 

--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -103,7 +103,7 @@
         replace="all"/>
 '>
 
-<!ENTITY collapse_spaces '
+<!ENTITY collapse_whitespace '
 <filter class="solr.PatternReplaceFilterFactory" pattern="&white;" replacement=" "
         replace="all"/>
 '>
@@ -148,7 +148,7 @@
 
 <!ENTITY cleanup '
 <filter class="solr.PatternReplaceFilterFactory" pattern="[&control;]" replacement="" replace="all"/>
-&collapse_spaces;
+&collapse_whitespace;
 &trim_leading_whitespace_and_punctuation;
 &trim_trailing_whitespace_and_punctuation;
 '>

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -130,8 +130,8 @@
 <field name="related_title" type="text_no_stem_or_synonyms" indexed="true" stored="true"   multiValued="true" />
 <copyField source="author" dest="authorStr"/>
 
+<field name="author_authoritative_browse" type="text_facet" indexed="true" stored="true" multiValued="true"/>
 <field name="author_authoritative_search" type="browse_match" indexed="true" stored="false" multiValued="true"/>
-<field name="author_authoritative_browse" type="text_facet" indexed="true" stored="true"/>
 <copyField source="author_authoritative_browse" dest="author_authoritative_search"/>
 <!-- Mixed title/author -->
 

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -130,8 +130,9 @@
 <field name="related_title" type="text_no_stem_or_synonyms" indexed="true" stored="true"   multiValued="true" />
 <copyField source="author" dest="authorStr"/>
 
-<field name="author_authoritative" type="browse_match" indexed="true" stored="true" multiValued="true"/>
-
+<field name="author_authoritative_search" type="browse_match" indexed="true" stored="false" multiValued="true"/>
+<field name="author_authoritative_browse" type="text_facet" indexed="true" stored="true"/>
+<copyField source="author_authoritative_browse" dest="author_authoritative_search"/>
 <!-- Mixed title/author -->
 
 <field name="title_author" type="text" indexed="true" stored="false" multiValued="true"/>

--- a/biblio/core.properties
+++ b/biblio/core.properties
@@ -1,1 +1,5 @@
+#Written by CorePropertiesLocator
+#Wed Aug 31 13:52:33 UTC 2022
+dataDir=data
 name=biblio
+config=solrconfig.xml

--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -149,7 +149,7 @@ end
 # For browse entries, we only want teh 100/110/111 and the 7xx counterparts _if_ the 7xx
 # has second-indicator 2 ("authoritative")
 # TODO: Figure out if forcing ind2=2 is too restrictive
-to_field 'author_authoritative', extract_marc_unless(
+to_field 'author_authoritative_browse', extract_marc_unless(
   "100abcdjq:110abcd:111acden:700|*2|abcdjq:710|*2|abcd:711|*2|acden",
 skipWaSeSS)
 


### PR DESCRIPTION
The list of term->docCount pairs exposed by solr lists the
terms using the analyzed value; the current setup gives
a fully-normalized version (lowercase, no punctuation,
etc.) which doesn't work as a display value, needed
when the term isn't found in the Name Authority File.

This provides fields `author_authoritative_browse` (values)
and `author_authoritative_search` (search target) to get
around this limitation.