### PR TITLE
DNDHELP-3584 Weird diacritic mismatches

### DIFF
--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -327,11 +327,11 @@
             &expand_state_abbreviations;
             &cleanup;
             &icu_downcase;
-            &stem; <!-- Wait!!! Esty thinks maybe this should go after overlay -->
             &overlay_keyword_token_copies_for_later_processing;
             &remove_english_posessives;
             &keyword_aware_icu_normalization;
             &try_to_deal_with_cjk;
+            &stem;
             &remove_duplicates_at_same_position;
         </analyzer>
         <analyzer type="query">
@@ -340,11 +340,11 @@
             &cleanup;
             &icu_downcase;
             &expand_synonyms_at_query_time_must_come_before_overlay_or_stemming;
-            &stem;
             &overlay_keyword_token_copies_for_later_processing;
             &remove_english_posessives;
             &keyword_aware_icu_normalization;
             &try_to_deal_with_cjk;
+            &stem;
             &remove_duplicates_at_same_position;
         </analyzer>
     </fieldType>


### PR DESCRIPTION
The stemmer acts on the suffice `ias` but not the suffix
`ías`, causing the text type (used, e.g., in `title_common`
to treat "Ciudadanías" and "Ciudadanias" differently.

This moves the stemmer further down the analysis chain
so it isn't invoked until after diacritic suppression.