### PR TITLE
added Date parsing to cat_date

### DIFF
--- a/umich_catalog_indexing/indexers/umich.rb
+++ b/umich_catalog_indexing/indexers/umich.rb
@@ -34,8 +34,6 @@ to_field 'cat_date', extract_marc('008[00-05]') do |rec, acc, context|
       '00000000'
     end 
   end
-  acc << '00000000'
-  acc.replace [acc.max]
 end
 
 

--- a/umich_catalog_indexing/indexers/umich.rb
+++ b/umich_catalog_indexing/indexers/umich.rb
@@ -24,9 +24,16 @@ end
 
 
 ###Date the record was added to the catalog####
-# cat_date -- first few digits of the 008 field
+# cat_date -- first few digits of the 006 field
 
 to_field 'cat_date', extract_marc('008[00-05]') do |rec, acc, context|
+  acc.map! do |str| 
+    begin
+      Date.parse(str).strftime("%Y%m%d") 
+    rescue
+      '00000000'
+    end 
+  end
   acc << '00000000'
   acc.replace [acc.max]
 end


### PR DESCRIPTION
Realized the 008 field only has two digit date which will mess up sorting when there's a list of items cataloged before and after 2000. This now also handles malformed 008.