### PR TITLE
Store the subject fields so they can be extracted by the /term handler

### DIFF
--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -534,11 +534,9 @@
                positionIncrementGap="&pig;">
         <analyzer>
             &standard_single_token_tokenizer;
+            &cleanup_whitespace;
             &remove_all_punctuation;
             &icu_downcase;
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="\s+" replacement=" " replace="all"
-            />
         </analyzer>
     </fieldType>
 
@@ -546,6 +544,7 @@
                positionIncrementGap="&pig;">
         <analyzer>
             &standard_single_token_tokenizer;
+            &cleanup_whitespace;
             &icu_downcase;
             <filter class="solr.PatternReplaceFilterFactory"
                     pattern="\s*--\s*" replacement="|" replace="all"

--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -535,8 +535,14 @@
         <analyzer>
             &standard_single_token_tokenizer;
             &cleanup_whitespace;
-            &remove_all_punctuation;
             &icu_downcase;
+            <filter class="solr.PatternReplaceFilterFactory"
+                    pattern="\s*--\s*" replacement="  "
+                    replace="all"
+            />
+            <filter class="solr.PatternReplaceFilterFactory"
+                    pattern="\p{P}" replacement=" " replace="all"
+            />
         </analyzer>
     </fieldType>
 
@@ -547,10 +553,11 @@
             &cleanup_whitespace;
             &icu_downcase;
             <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="\s*--\s*" replacement="|" replace="all"
+                    pattern="\s*--\s*" replacement="  "
+                    replace="all"
             />
             <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="[^\P{P}|]" replacement="" replace="all"
+                    pattern="\p{P}" replacement=" " replace="all"
             />
         </analyzer>
     </fieldType>

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -222,8 +222,8 @@
 <copyField source="hlb3" dest="hlb3Str"/>
 <copyField source="genre" dest="genreStr"/>
 
-<field name="lc_subject_display"     type="string" indexed="false" stored="true" multiValued="true"/>
-<field name="non_lc_subject_display" type="string" indexed="false" stored="true" multiValued="true"/>
+<field name="lc_subject_display"     type="text_facet" indexed="true" stored="true" multiValued="true"/>
+<field name="non_lc_subject_display" type="text_facet" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Time and Place -->
 

--- a/biblio/core.properties
+++ b/biblio/core.properties
@@ -1,5 +1,5 @@
 #Written by CorePropertiesLocator
-#Wed Aug 31 13:52:33 UTC 2022
+#Wed Sep 07 17:56:46 UTC 2022
 dataDir=data
 name=biblio
 config=solrconfig.xml


### PR DESCRIPTION
The subjects weren't being saved in such a way that it was easy to get to them with associated document counts. This changes the type to `text_facet` (which only does very basic cleanup) and indexes them.

Also, join subject parts with <space><space> instead of `|` for better sorting. 