### PR TITLE
Unify method of normalizing text for catalog solr and browse

### DIFF
--- a/biblio/conf/schema.xml
+++ b/biblio/conf/schema.xml
@@ -519,14 +519,28 @@
     </fieldType>
 
 
-    <!-- An even less aggressive exactish, primarily for browse matching -->
+    <!-- An even less aggressive exactish, primarily for browse matching.
+         This matches the ruby code from the authority_browse code
+
+                WHICH_PUNCT_TO_SPACIFY = /[:\-]+/
+                def sort_key(str)
+                  str = unicode_normalize(str)
+                  str = str.gsub(WHICH_PUNCT_TO_SPACIFY, " ")
+                  str = str.gsub(/\p{P}/, '')
+                  cleanup_spaces(str)
+                end
+     -->
     <fieldType name="browse_match" class="solr.TextField" positionIncrementGap="&pig;">
         <analyzer>
             &less_aggressive_pre_tokenization_character_substitution;
             &tokenize_into_one_big_token;
-            &cleanup_whitespace;
-            &remove_unnecessary_ending_punctuation;
             &icu_case_folding_and_normalization;
+            <filter class="solr.PatternReplaceFilterFactory"
+                    pattern="[:\-]+" replacement=" "
+                    replace="all"
+            />
+            &remove_all_punctuation;
+            &cleanup_whitespace;
         </analyzer>
     </fieldType>
 

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -131,7 +131,7 @@
 <copyField source="author" dest="authorStr"/>
 
 <field name="author_authoritative_browse" type="text_facet" indexed="true" stored="true" multiValued="true"/>
-<field name="author_authoritative_search" type="browse_match" indexed="true" stored="false" multiValued="true"/>
+<field name="author_authoritative_search" type="browse_match" indexed="true" stored="true" multiValued="true"/>
 <copyField source="author_authoritative_browse" dest="author_authoritative_search"/>
 <!-- Mixed title/author -->
 


### PR DESCRIPTION
The `browse_match` fieldType has been changed to mirror what we're doing when generating the authorities
data, in the hopes that the number of matches reported in the browse will match the number found when you click on the link. This is currently used by author_authoritative_search, the target for links coming from the author browse.

In addition to the normal icu normalization stuff, this removes all punctuation from the analyzed string in two steps, first turning any of `-:/()[]{}=&` into spaces and then deleting everything else.

