### PR TITLE
makes sure only one cat_date is added

### DIFF
--- a/umich_catalog_indexing/bin/index_a_file.rb
+++ b/umich_catalog_indexing/bin/index_a_file.rb
@@ -1,0 +1,39 @@
+#!/usr/local/bin/ruby
+
+require "optparse"
+require "logger"
+require_relative "../lib/sidekiq_jobs"
+
+solr_url = ENV.fetch("REINDEX_SOLR_URL") 
+solr = "reindex"
+file = ""
+OptionParser.new do |opts|
+  opts.on("-f", "--file FILE", "File on sftp server to index; Required") do |x|
+    file = x
+  end
+  opts.on("-sSOLR", "--solr=SOLR", "Solr url to index into; options are: reindex|hatcher_prod|macc_prod; Default is reindex: #{solr_url}") do |x|
+    case x
+    when "reindex"
+      solr_url = ENV.fetch("REINDEX_SOLR_URL") 
+    when "hatcher_prod"
+      solr_url = ENV.fetch("HATCHER_PRODUCTION_SOLR_URL") 
+    when "macc_prod"
+      solr_url = ENV.fetch("MACC_PRODUCTION_SOLR_URL") 
+    else
+      raise ArgumentError, "solr must be reindex|hatcher_prod|macc_prod"
+    end
+    solr = x
+  end
+   opts.on("-h", "--help", "Prints this help") do
+     puts opts
+     exit
+   end
+end.parse!
+
+if solr == "reindex"
+  puts "indexing #{file} into #{solr_url} in reindex queue"
+  IndexIt.set(queue: "reindex").perform_async(file, solr_url)
+else
+  puts "indexing #{file} into #{solr_url} in default queue"
+  IndexIt.perform_async(file, solr_url)
+end

--- a/umich_catalog_indexing/indexers/umich.rb
+++ b/umich_catalog_indexing/indexers/umich.rb
@@ -25,6 +25,9 @@ end
 
 ###Date the record was added to the catalog####
 # cat_date -- first few digits of the 006 field
+# the acc.replace line is there because sometimes there are multiple
+# 008 fields and that messes stuff up. example: 99187608751706381 
+# from 2022-10-14
 
 to_field 'cat_date', extract_marc('008[00-05]') do |rec, acc, context|
   acc.map! do |str| 
@@ -34,6 +37,7 @@ to_field 'cat_date', extract_marc('008[00-05]') do |rec, acc, context|
       '00000000'
     end 
   end
+  acc.replace [acc.max]
 end
 
 


### PR DESCRIPTION
Indexing failed on 2022-10-14 because a community zone record had 3 `008` fields which created 3 potential cat_dates. This code forces cat_date to be the field with the biggest number.  
 
It also adds a convenience script to start doing an alma index for any file in the sftp directory to any solr.