### PR TITLE
Schema: icu-normalize facets, add automatic date_of_index

### DIFF
--- a/biblio/conf/managed-schema
+++ b/biblio/conf/managed-schema
@@ -232,6 +232,10 @@
 <charFilter class="solr.ICUNormalizer2CharFilterFactory"/>
 '>
 
+<!ENTITY icu_normalization_no_case_folding '
+<filter class="solr.ICUNormalizer2FilterFactory" name="nfkc" mode="compose"/>
+'>
+
 <!ENTITY icu_case_folding_and_normalization '
 <filter class="solr.ICUFoldingFilterFactory"/>
 '>
@@ -594,6 +598,7 @@
         <analyzer>
             &tokenize_into_one_big_token;
             &remove_unnecessary_ending_punctuation;
+	    &icu_normalization_no_case_folding;
             &cleanup;
         </analyzer>
     </fieldType>

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -5,6 +5,7 @@
 
 <field name="input_file_name" type="string" indexed="true" stored="true" docValues="true" multiValued="false"/>
 <field name="indexing_date" type="int" indexed="true" stored="true" docValues="true" multiValued="false"/>
+<field name="date_of_index" type="date" indexed="true" stored="true" default="NOW/DAY" multiValued="false"/>
 
 <!-- Core Fields  -->
 


### PR DESCRIPTION
* Add `&icu_normalization_no_case_folding;` to the `text_facet` type to avoid duplicates in facet lists (specifically author, as reported by the solr reading group.
* Add a new field, `date_of_index`, that is automatically populated when a document is added.