### PR TITLE
Add fields and indexing rules for subject_browse

### DIFF
--- a/biblio/conf/managed-schema
+++ b/biblio/conf/managed-schema
@@ -555,12 +555,16 @@
             &cleanup;
             &icu_case_folding_and_normalization;
             <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="\s*--\s*" replacement="  "
+                    pattern="\s*--\s*" replacement="DOUBLEDASH"
                     replace="all"
             />
             <filter class="solr.PatternReplaceFilterFactory"
                     pattern="\p{P}" replacement=" " replace="all"
             />
+						<filter class="solr.PatternReplaceFilterFactory"
+							pattern="DOUBLEDASH" replacement="--"
+							replace="all"
+						/>
         </analyzer>
     </fieldType>
 

--- a/biblio/conf/managed-schema
+++ b/biblio/conf/managed-schema
@@ -562,7 +562,7 @@
                     pattern="\p{P}" replacement=" " replace="all"
             />
 						<filter class="solr.PatternReplaceFilterFactory"
-							pattern="DOUBLEDASH" replacement="--"
+							pattern="DOUBLEDASH" replacement=" -- "
 							replace="all"
 						/>
         </analyzer>

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -230,6 +230,7 @@
 
 <field name="lc_subject_display"     type="text_facet" indexed="true" stored="true" multiValued="true"/>
 <field name="non_lc_subject_display" type="text_facet" indexed="true" stored="true" multiValued="true"/>
+<field name="subject_browse" type="lc_subject" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Time and Place -->
 

--- a/biblio/core.properties
+++ b/biblio/core.properties
@@ -1,5 +1,5 @@
 #Written by CorePropertiesLocator
-#Wed Sep 07 17:56:46 UTC 2022
+#Wed Jan 25 19:10:39 UTC 2023
+config=solrconfig.xml
 dataDir=data
 name=biblio
-config=solrconfig.xml

--- a/umich_catalog_indexing/Gemfile.lock
+++ b/umich_catalog_indexing/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     anyway_config (2.3.0)
       ruby-next-core (>= 0.14.0)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
@@ -38,6 +39,7 @@ GEM
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
     dry-initializer (3.0.4)
+    ffi (1.15.5)
     ffi (1.15.5-java)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -81,10 +83,16 @@ GEM
     mime-types-data (3.2022.0105)
     minitest (5.15.0)
     multi_xml (0.6.0)
+    mysql2 (0.5.4)
     naconormalizer (1.0.1-java)
     nokogiri (1.13.4-java)
       racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-darwin)
+      racc (~> 1.4)
     prometheus-client (2.1.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     pry (0.14.1-java)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -95,6 +103,7 @@ GEM
     psych (4.0.3-java)
       jar-dependencies (>= 0.1.7)
     public_suffix (4.0.7)
+    racc (1.6.0)
     racc (1.6.0-java)
     rack (2.2.3)
     rake (13.0.6)
@@ -140,6 +149,8 @@ GEM
       marc-marc4j (~> 1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
     unf (0.1.4-java)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -164,10 +175,12 @@ GEM
   remote: https://rubygems.pkg.github.com/mlibrary/
   specs:
     sftp (0.2.1)
+    unf_ext (0.0.8.2)
 
 PLATFORMS
   universal-java-1.8
   universal-java-11
+  x86_64-darwin-21
 
 DEPENDENCIES
   alma_rest_client!

--- a/umich_catalog_indexing/indexers/subject_topic.rb
+++ b/umich_catalog_indexing/indexers/subject_topic.rb
@@ -36,3 +36,5 @@ to_field "topic", extract_marc_unless(%w(
 
 to_field 'lc_subject_display', lcsh_subjects
 to_field 'non_lc_subject_display', non_lcsh_subjects
+
+to_field "subject_browse", lcsh_subjects

--- a/umich_catalog_indexing/lib/umich_traject/subject_macros.rb
+++ b/umich_catalog_indexing/lib/umich_traject/subject_macros.rb
@@ -29,7 +29,7 @@ module Traject::Macros::UMich
     end
 
     def self.subject_string(field)
-      self.normalize_subject(field.subfields.select { |sf| LOWER_LETTER_PAT.match(sf.code) }.map(&:value).join(" -- "))
+      self.normalize_subject(field.subfields.select { |sf| LOWER_LETTER_PAT.match(sf.code) }.map(&:value).join("--"))
     end
 
     def self.subjects_by_ind2(r, ind2_pat)

--- a/umich_catalog_indexing/lib/umich_traject/subject_macros.rb
+++ b/umich_catalog_indexing/lib/umich_traject/subject_macros.rb
@@ -16,7 +16,7 @@ module Traject::Macros::UMich
     STRIP_PUNCT_PAT = /\A\p{Punct}*(.*?)\p{Punct}*\Z/
 
     def self.normalize_subject(str)
-      STRIP_PUNCT_PAT.match(str)[1].gsub("/\s+/", ' ')
+      STRIP_PUNCT_PAT.match(str)[1].gsub("/\s+/", ' ').strip
     end
 
     def self.eight_eighties_for(r, f)
@@ -29,7 +29,7 @@ module Traject::Macros::UMich
     end
 
     def self.subject_string(field)
-      self.normalize_subject(field.subfields.select { |sf| LOWER_LETTER_PAT.match(sf.code) }.map(&:value).join("--"))
+      self.normalize_subject(field.subfields.select { |sf| LOWER_LETTER_PAT.match(sf.code) }.map(&:value).join(" -- "))
     end
 
     def self.subjects_by_ind2(r, ind2_pat)


### PR DESCRIPTION
Our existing `lc_subject` field _almost_ but not quite gets us what the librarians want. This adds a new field `subject_browse` for parallel naming with `callnumber_browse` that holds all the stuff added to the subject browse index. It does basic normalization to the indexed value, as well as substitution `/\s*--\s*/ =>  " -- "`