### PR TITLE
Better subject detection and display

### DIFF
--- a/umich_catalog_indexing/lib/common/subject.rb
+++ b/umich_catalog_indexing/lib/common/subject.rb
@@ -23,7 +23,7 @@ module Common::Subject
     LCSubject.lc_subject_field?(field)
   end
 
-  # Determin the 880 (linking fields) for the given field. Should probably be pulled
+  # Determine the 880 (linking fields) for the given field. Should probably be pulled
   # out into a more generically-available macro
   # @param [MARC::Record] record The record
   # @param [MARC::DataField] field The field you want to try to match

--- a/umich_catalog_indexing/lib/common/subject/lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subject/lc_subject.rb
@@ -28,14 +28,14 @@ module Common::Subject
     # @param [MARC::DataField] field A 6XX field
     # @return [Boolean]
     def self.lc_subject_field?(field)
-      return false unless SUBJECT_FIELDS.include?(field.tag)
-      return false if bad_ind2_subject_field?(field)
-      return true if field.indicator2 == "0"
+      SUBJECT_FIELDS.include?(field.tag) && 
+        field.indicator2 == "0" &&
+        lcsh_subject_field_2?(field)
     end
 
     # @param [MARC::DataField] field A 6xx field
-    def bad_ind2_subject_field?(field)
-      field.indicator2 == "0" and (field["2"] != "lcsh")
+    def self.lcsh_subject_field_2?(field)
+      field["2"].nil? || field["2"] == "lsch"
     end
 
     def initialize(field)

--- a/umich_catalog_indexing/lib/common/subject/lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subject/lc_subject.rb
@@ -28,8 +28,14 @@ module Common::Subject
     # @param [MARC::DataField] field A 6XX field
     # @return [Boolean]
     def self.lc_subject_field?(field)
-      SUBJECT_FIELDS.include?(field.tag) and
-        field.indicator2 == '0' and field["2"] != "lcsh"
+      return false unless SUBJECT_FIELDS.include?(field.tag)
+      return false if bad_ind2_subject_field?(field)
+      return true if field.indicator2 == "0"
+    end
+
+    # @param [MARC::DataField] field A 6xx field
+    def bad_ind2_subject_field?(field)
+      field.indicator2 == "0" and (field["2"] != "lcsh")
     end
 
     def initialize(field)

--- a/umich_catalog_indexing/lib/common/subject/non_lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subject/non_lc_subject.rb
@@ -3,10 +3,9 @@
 require_relative "lc_subject"
 
 module Common::Subject
-  # There are a wide variety of non-LC subject types (e.g., MESH). For the
-  # moment, just treat them all the same as LC Hierarchical, with delimiters
-  # between every subfield value
-  class NonLCSubject < Common::Subject::LCSubjectHierarchical
+  # According to the LC docs, non-LC subjects follow the same formatting and data
+  # standards as LC, so this needs not do anything special until we learn otherwise.
+  class NonLCSubject < Common::Subject::LCSubject
 
     # Here for testing purposes to distinguish from the LC subjects
     # @return [Boolean]

--- a/umich_catalog_indexing/spec/common/subject/lc_subject_spec.rb
+++ b/umich_catalog_indexing/spec/common/subject/lc_subject_spec.rb
@@ -7,8 +7,29 @@ RSpec.describe Common::Subject::LCSubject do
       return r
     end
   end
+  let(:subject_fields) do
+    Common::Subject.lc_subject_fields(record)
+  end
   let(:subject_field) do
-    Common::Subject.lc_subject_fields(record).first
+    subject_fields.first
+  end
+  let(:non_lc_subject_field) do
+    subject_fields[2]
+  end
+  let(:wrongindicator_subject_field) do
+    MARC::DataField.new("650", "0", "0", ["a", "subjectA"], ["2", "gnd"])
+  end
+  context ".lc_subject_field?" do
+    it "returns true for appropriate subject field" do
+      expect(described_class.lc_subject_field?(subject_field)).to eq(true)
+    end
+    it "returns false for field with incorrect tag" do
+      not_lc_subject = instance_double(MARC::DataField, tag: "600", indicator2: "1")
+      expect(described_class.lc_subject_field?(not_lc_subject)).to eq(false)
+    end
+    it "returns false for a field with ind2=0 but a $2 that says otherwise" do
+      expect(described_class.lc_subject_field?(wrongindicator_subject_field)).to eq(false)
+    end
   end
   context "#subject_data_subfield_codes" do
     it "returns array of subfields with a-z codes" do

--- a/umich_catalog_indexing/spec/common/subject/non_lc_subject_spec.rb
+++ b/umich_catalog_indexing/spec/common/subject/non_lc_subject_spec.rb
@@ -17,10 +17,4 @@ RSpec.describe Common::Subject::NonLCSubject do
       expect(subject.lc_subject_field?).to eq(false)
     end
   end
-
-  context "subject_string" do
-    it "acts like an LCSubjectHierarchical" do
-      expect(subject.subject_string).to eq("a--b--c")
-    end
-  end
 end

--- a/umich_catalog_indexing/spec/common/subject/subject_spec.rb
+++ b/umich_catalog_indexing/spec/common/subject/subject_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe Common::Subject do
   let(:non_lc_subject_field) do
     subject_fields[2]
   end
+  let(:wrongindicator_subject_field) do
+    MARC::DataField.new("650", "0", "0", ["a", "subjectA"], ["2" "gnd"])
+  end
   context ".subject_field?" do
     it "returns true for appropriate subject field" do
       expect(described_class.subject_field?(lc_subject_field)).to eq(true)
@@ -38,6 +41,9 @@ RSpec.describe Common::Subject do
     it "returns false for field with incorrect tag" do
       not_lc_subject = instance_double(MARC::DataField, tag: "600", indicator2: "1")
       expect(described_class.lc_subject_field?(not_lc_subject)).to eq(false)
+    end
+    it "returns false for a field with ind2=0 but a $2 that says otherwise" do
+      expect(described_class.lc_subject_field?(wrongindicator_subject_field)).to eq(false)
     end
   end
   context ".linked_fields_for" do

--- a/umich_catalog_indexing/spec/common/subject/subject_spec.rb
+++ b/umich_catalog_indexing/spec/common/subject/subject_spec.rb
@@ -34,18 +34,6 @@ RSpec.describe Common::Subject do
       expect(described_class.subject_field?(not_subject)).to eq(false)
     end
   end
-  context ".lc_subject_field?" do
-    it "returns true for appropriate subject field" do
-      expect(described_class.lc_subject_field?(lc_subject_field)).to eq(true)
-    end
-    it "returns false for field with incorrect tag" do
-      not_lc_subject = instance_double(MARC::DataField, tag: "600", indicator2: "1")
-      expect(described_class.lc_subject_field?(not_lc_subject)).to eq(false)
-    end
-    it "returns false for a field with ind2=0 but a $2 that says otherwise" do
-      expect(described_class.lc_subject_field?(wrongindicator_subject_field)).to eq(false)
-    end
-  end
   context ".linked_fields_for" do
     it "returns a linking field?" do
       rec = record_with_880


### PR DESCRIPTION
Two changes:
  * An LC subject is now one that has ind2=0 PLUS it can't have a $2 that indicates it's from somewhere else. We're getting stuff from the community records that are wrong.
  * A closer reading of the LoC MARC stuff indicates that non-LC are formated the same as LC. This means that NonLCSubject can just inherit from LCSubject.