### PR TITLE
Add field `subject_browse_leftanchored`

### DIFF
--- a/biblio/conf/managed-schema
+++ b/biblio/conf/managed-schema
@@ -588,6 +588,22 @@
         </analyzer>
     </fieldType>
 
+		<fieldType name="lc_subject_left_anchored" class="solr.TextField" positionIncrementGap="&pig;">
+			<analyzer>
+		    &tokenize_with_icu;
+				&icu_case_folding_and_normalization;
+				<filter class="solr.PatternReplaceFilterFactory"
+				pattern="\s*--\s*" replacement="  "
+				replace="all"
+				/>
+				<filter class="solr.PatternReplaceFilterFactory"
+				pattern="\p{P}" replacement=" " replace="all"
+				/>
+				&cleanup;
+				<filter class="edu.umich.lib.solr_filters.LeftAnchoredSearchFilterFactory"/>
+		</analyzer>
+		</fieldType>
+
 
     <!-- =============================================================
                   A Facet type

--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -242,7 +242,10 @@
 
 <field name="subject_browse_terms" type="text_facet" indexed="true" stored="true" multiValued="true"/>
 <field name="subject_browse_search" type="lc_subject" indexed="true" stored="false" multiValued="true"/>
+<field name="subject_browse_leftanchored" type="lc_subject_left_anchored" indexed="true" stored="false" multiValued="true"/>
+
 <copyField source="subject_browse_terms" dest="subject_browse_search"/>
+<copyField source="subject_browse_terms" dest="subject_browse_leftanchored"/>
 
 
 


### PR DESCRIPTION
of type `lc_subject_left_anchored`

Adds a field of LC Subjects (same data as browse) which is left-anchored by word (NOT by letter). Normal rules for removing punctuation apply.