### PR TITLE
Add extra fields for alma digital

### DIFF
--- a/umich_catalog_indexing/lib/umich_traject/digital_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/digital_holding.rb
@@ -4,8 +4,9 @@ module Traject
       def initialize(avd)
         @avd = avd
       end
+      # This concatenates the file type and the public note
       def note
-        @avd["z"]
+        [@avd["d"],@avd["z"]].compact.join("; ")
       end
       def link
         URI::Parser.new.escape(@avd["u"].sub("01UMICH_INST:FLINT","01UMICH_INST:UMICH"))
@@ -19,8 +20,9 @@ module Traject
       def link_text
         "Available online"
       end
+      # This is the label
       def description
-        ""
+        @avd["l"]
       end
       def finding_aid
         false

--- a/umich_catalog_indexing/lib/umich_traject/digital_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/digital_holding.rb
@@ -5,37 +5,36 @@ module Traject
         @avd = avd
       end
       # This concatenates the file type and the public note
-      def note
-        [@avd["d"],@avd["z"]].compact.join("; ")
+      def public_note
+        @avd["z"]
       end
       def link
         URI::Parser.new.escape(@avd["u"].sub("01UMICH_INST:FLINT","01UMICH_INST:UMICH"))
       end
       def library
-        "ELEC"
-      end
-      def status
-        "Available"
+        "ALMA_DIGITAL"
       end
       def link_text
         "Available online"
       end
-      # This is the label
-      def description
+      def label
         @avd["l"]
+      end
+      # This is effectively the file type(s)
+      def delivery_description
+        @avd["d"]
       end
       def finding_aid
         false
       end
       def to_h
         {
-          finding_aid: finding_aid,
           library: library,
           link: link,
           link_text: link_text,
-          note: note,
-          status: status,
-          description: description
+          delivery_description: delivery_description,
+          label: label,
+          public_note: public_note,
         }
       end
 

--- a/umich_catalog_indexing/spec/fixtures/arborist_avd.xml
+++ b/umich_catalog_indexing/spec/fixtures/arborist_avd.xml
@@ -1,3 +1,1008 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
-<collection>  <record><leader>00000nas a2200289 a 4500</leader><controlfield tag="005">20200722183858.0</controlfield><controlfield tag="006">m        d        </controlfield><controlfield tag="007">cr bn ---auaua</controlfield><controlfield tag="008">931217c19929999ilubr p       0    0eng d</controlfield><controlfield tag="001">990027318490106381</controlfield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(MiU)002731849MIU01</subfield></datafield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">sn 93026898</subfield></datafield><datafield tag="022" ind1=" " ind2=" "><subfield code="a">1542-2399</subfield><subfield code="0">http://worldcat.org/issn/1542-2399</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(OCoLC)ocm25376224</subfield></datafield><datafield tag="040" ind1=" " ind2=" "><subfield code="a">VXG</subfield><subfield code="c">VXG</subfield><subfield code="d">FUG</subfield><subfield code="d">WAU</subfield><subfield code="d">EYM</subfield></datafield><datafield tag="042" ind1=" " ind2=" "><subfield code="a">lcd</subfield></datafield><datafield tag="050" ind1="1" ind2="4"><subfield code="a">SB435</subfield><subfield code="b">.A7</subfield></datafield><datafield tag="245" ind1="0" ind2="0"><subfield code="a">Arborist news /</subfield><subfield code="c">International Society of Arboriculture.</subfield></datafield><datafield tag="260" ind1=" " ind2=" "><subfield code="a">Savoy, IL :</subfield><subfield code="b">The Society.</subfield></datafield><datafield tag="300" ind1=" " ind2=" "><subfield code="a">v. :</subfield><subfield code="b">ill. ;</subfield><subfield code="c">28 cm</subfield></datafield><datafield tag="310" ind1=" " ind2=" "><subfield code="a">Bimonthly</subfield></datafield><datafield tag="362" ind1="1" ind2=" "><subfield code="a">Began with: Vol. 1, no. 1 (Feb. 1992).</subfield></datafield><datafield tag="500" ind1=" " ind2=" "><subfield code="a">Description based on: Vol. 2, no. 3 (June 1993); title from cover.</subfield></datafield><datafield tag="610" ind1="2" ind2="0"><subfield code="a">International Society of Arboriculture</subfield><subfield code="v">Periodicals.</subfield><subfield code="0">http://id.loc.gov/authorities/names/n86824788</subfield><subfield code="0">http://viaf.org/viaf/sourceID/LC|n86824788</subfield></datafield><datafield tag="650" ind1=" " ind2="0"><subfield code="a">Arboriculture</subfield><subfield code="v">Periodicals.</subfield><subfield code="0">http://id.loc.gov/authorities/subjects/sh85006470</subfield></datafield><datafield tag="650" ind1=" " ind2="0"><subfield code="a">Trees</subfield><subfield code="v">Periodicals.</subfield><subfield code="0">http://id.loc.gov/authorities/subjects/sh85137241</subfield></datafield><datafield tag="710" ind1="2" ind2=" "><subfield code="a">International Society of Arboriculture.</subfield><subfield code="0">http://id.loc.gov/authorities/names/n86824788</subfield><subfield code="0">http://viaf.org/viaf/sourceID/LC|n86824788</subfield></datafield><datafield tag="856" ind1="4" ind2="1"><subfield code="3">12 months ago-</subfield><subfield code="z">Institutional password required for access to the International Society of Arboriculture online version; authentication required:</subfield><subfield code="u">https://apps.lib.umich.edu/pk/resource.php?002731849</subfield><subfield code="x">http://www.isa-arbor.com/Publications/Arborist-News</subfield><subfield code="m">International Society of Arboriculture</subfield></datafield><datafield tag="856" ind1="4" ind2="1"><subfield code="3">Feb. 2002-12 months ago</subfield><subfield code="z">Access to archived issues via the International Society of Arboriculture online version:</subfield><subfield code="u">http://www.isa-arbor.com/Publications/Arborist-News#archived</subfield><subfield code="m">archived issues via the International Society of Arboriculture</subfield></datafield><datafield tag="997" ind1=" " ind2=" "><subfield code="a">MARS</subfield></datafield><datafield tag="998" ind1=" " ind2=" "><subfield code="c">lene-rdu MaintCorrEserial 20200722 ELEC</subfield></datafield><datafield tag="998" ind1=" " ind2=" "><subfield code="c">lene-rdu MaintCorrESerial 20180927 ELEC</subfield></datafield><datafield tag="998" ind1=" " ind2=" "><subfield code="c">lene-rdu AddVolSerial 20180521</subfield></datafield><datafield tag="998" ind1=" " ind2=" "><subfield code="c">sc5</subfield></datafield><datafield tag="958" ind1=" " ind2=" "><subfield code="a">MiU</subfield></datafield><datafield tag="959" ind1=" " ind2=" "><subfield code="a">(notis)ULAPJ0006</subfield></datafield><datafield tag="995" ind1=" " ind2=" "><subfield code="a">20</subfield></datafield><datafield tag="787" ind1="0" ind2=" "><subfield code="t">Birds</subfield><subfield code="w">811230624800006381</subfield><subfield code="i">Alma Collection</subfield></datafield><datafield tag="787" ind1="0" ind2=" "><subfield code="t">MRIO Top Level Collection</subfield><subfield code="w">811230624810006381</subfield><subfield code="i">Alma Collection</subfield></datafield><datafield tag="BIB" ind1=" " ind2=" "><subfield code="u">2021-08-17 11:36:20 US/Eastern</subfield><subfield code="c">2021-06-21 06:05:49 US/Eastern</subfield><subfield code="s">false</subfield></datafield><datafield tag="AVD" ind1="0" ind2=" "><subfield code="z">This is a Public Note</subfield><subfield code="u">https://umich-psb.alma.exlibrisgroup.com/discovery/delivery/01UMICH_INST:FLINT/121230624780006381</subfield></datafield><datafield tag="E56" ind1=" " ind2=" "><subfield code="j">2021-06-23 18:18:09 US/Eastern</subfield><subfield code="m">archived issues via the International Society of Arboriculture</subfield><subfield code="p">System</subfield><subfield code="i">2021-06-23 18:17:59 US/Eastern</subfield><subfield code="u">https://na04-psb.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=531031051570006381&amp;Force_direct=true</subfield><subfield code="w">P2E_JOB</subfield><subfield code="g">531031051570006381</subfield><subfield code="x">UMAA proxy</subfield><subfield code="1">2021-06-23 22:17:59</subfield><subfield code="y">true</subfield><subfield code="l">ELEC</subfield><subfield code="t">static</subfield><subfield code="r">500443441</subfield><subfield code="6">521031051580006381</subfield><subfield code="v">https://umich.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?&amp;rfr_id=info:sid/primo.exlibrisgroup.com&amp;svc_dat=CTO?u.ignore_date_coverage=true?u.ignore_date_coverage=true&amp;rft.mms_id=990027318490106381</subfield><subfield code="z">Access to archived issues via the International Society of Arboriculture online version:</subfield><subfield code="s">Available</subfield><subfield code="f">JOURNAL</subfield><subfield code="e">http://www.isa-arbor.com/Publications/Arborist-News#archived</subfield><subfield code="8">531031051570006381</subfield></datafield><datafield tag="E56" ind1=" " ind2=" "><subfield code="j">2021-06-23 18:18:09 US/Eastern</subfield><subfield code="m">International Society of Arboriculture</subfield><subfield code="p">System</subfield><subfield code="i">2021-06-23 18:17:59 US/Eastern</subfield><subfield code="u">https://na04-psb.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=531031051590006381&amp;Force_direct=true</subfield><subfield code="w">P2E_JOB</subfield><subfield code="g">531031051590006381</subfield><subfield code="x">UMAA proxy</subfield><subfield code="1">2021-06-23 22:17:59</subfield><subfield code="y">true</subfield><subfield code="l">ELEC</subfield><subfield code="t">static</subfield><subfield code="r">500443441</subfield><subfield code="6">521031051600006381</subfield><subfield code="v">https://umich.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?&amp;rfr_id=info:sid/primo.exlibrisgroup.com&amp;svc_dat=CTO?u.ignore_date_coverage=true?u.ignore_date_coverage=true&amp;rft.mms_id=990027318490106381</subfield><subfield code="z">Institutional password required for access to the International Society of Arboriculture online version; authentication required:</subfield><subfield code="s">Available</subfield><subfield code="f">JOURNAL</subfield><subfield code="e">https://apps.lib.umich.edu/pk/resource.php?002731849</subfield><subfield code="8">531031051590006381</subfield></datafield><datafield tag="852" ind1="0" ind2=" "><subfield code="b">SHAP</subfield><subfield code="a">MiU</subfield><subfield code="c">SOVR</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="z">CURRENT ISSUES IN SERIAL SERVICES, 203 NORTH HATCHER</subfield><subfield code="z">MISSING: 24 no.1-2 2015, v.28 no.6 2019</subfield><subfield code="8">22767949280006381</subfield></datafield><datafield tag="866" ind1="3" ind2="2"><subfield code="a">2-</subfield><subfield code="8">22767949280006381</subfield></datafield><datafield tag="866" ind1="3" ind2="2"><subfield code="a">1993-</subfield><subfield code="8">22767949280006381</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113546</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590060006381</subfield><subfield code="z">v.31:no.2(2022:Apr.)</subfield><subfield code="p">08</subfield><subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015098302691</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948940006381</subfield><subfield code="z">v.26 2017</subfield><subfield code="p">01</subfield><subfield code="r">2017-02-15 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015098283776</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948930006381</subfield><subfield code="z">v.25 2016</subfield><subfield code="p">01</subfield><subfield code="r">2016-02-25 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113548</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590040006381</subfield><subfield code="z">v.31:no.4(2022:Aug.)</subfield><subfield code="p">08</subfield><subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015081678495</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948960006381</subfield><subfield code="z">v.24 no.3-6 2015</subfield><subfield code="p">01</subfield><subfield code="r">2015-06-12 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113547</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590050006381</subfield><subfield code="z">v.31:no.3(2022:June)</subfield><subfield code="p">08</subfield><subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113545</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590070006381</subfield><subfield code="z">v.31:no.1(2022:Feb.)</subfield><subfield code="p">08</subfield><subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="a">39015060977553</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015060977553 ic 20210127</subfield><subfield code="7">23767949100006381</subfield><subfield code="z">v.14 2005</subfield><subfield code="p">01</subfield><subfield code="r">2005-08-09 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113549</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590030006381</subfield><subfield code="z">v.31:no.5(2022:Oct.)</subfield><subfield code="p">08</subfield><subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015090095483</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948970006381</subfield><subfield code="z">v.23 2014</subfield><subfield code="p">01</subfield><subfield code="r">2014-02-07 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015090035273</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948990006381</subfield><subfield code="z">v.22 2013</subfield><subfield code="p">01</subfield><subfield code="r">2013-03-15 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015089014933</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767949080006381</subfield><subfield code="z">v.17 2008</subfield><subfield code="p">01</subfield><subfield code="r">2008-02-20 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015085229675</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767949060006381</subfield><subfield code="z">v.18 2009</subfield><subfield code="p">01</subfield><subfield code="r">2009-02-16 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113551</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590010006381</subfield><subfield code="z">v.32:no.1(2023:Feb.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015055714276</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015055714276 ic 20210127</subfield><subfield code="7">23767949130006381</subfield><subfield code="z">v.11 2002</subfield><subfield code="p">01</subfield><subfield code="r">2003-05-15 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015053932409</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015053932409 ic 20210127</subfield><subfield code="7">23767949150006381</subfield><subfield code="z">v.9 2000</subfield><subfield code="p">01</subfield><subfield code="r">2002-04-04 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015046265354</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015046265354 ic 20210127</subfield><subfield code="7">23767949170006381</subfield><subfield code="z">v.7 1998</subfield><subfield code="p">01</subfield><subfield code="r">1999-09-28 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="a">39015060977546</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015060977546 ic 20210127</subfield><subfield code="7">23767949110006381</subfield><subfield code="z">v.13 2004</subfield><subfield code="p">01</subfield><subfield code="r">2004-10-29 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015089014784</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767949020006381</subfield><subfield code="z">v.20 2011</subfield><subfield code="p">01</subfield><subfield code="r">2011-02-21 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A30841</subfield><subfield code="e">SOVR</subfield><subfield code="7">231173897060006381</subfield><subfield code="z">v.30:no.3(2021:June)</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015090404529</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767949000006381</subfield><subfield code="z">v.21 2012</subfield><subfield code="p">01</subfield><subfield code="r">2012-02-01 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A30843</subfield><subfield code="e">SOVR</subfield><subfield code="7">231173897040006381</subfield><subfield code="z">v.30:no.5(2021:Oct.)</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A30839</subfield><subfield code="e">SOVR</subfield><subfield code="7">231173897080006381</subfield><subfield code="z">v.30:no.1(2021:Feb.)</subfield><subfield code="r">2022-01-28 13:54:44 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1400</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948820006381</subfield><subfield code="z">v.29:no.4(2020:Aug.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1410</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948810006381</subfield><subfield code="z">v.29:no.5(2020:Oct.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1390</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948830006381</subfield><subfield code="z">v.29:no.3(2020:Jun.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113553</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228589990006381</subfield><subfield code="z">v.32:no.3(2023:June)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1350</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948850006381</subfield><subfield code="z">v.28 no.6(2019:Dec.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1370</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948860006381</subfield><subfield code="z">v.29:no.1(2020:Feb.)</subfield><subfield code="p">08</subfield><subfield code="r">2020-02-27 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1420</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948800006381</subfield><subfield code="z">v.29:no.6(2020:Dec.)</subfield><subfield code="p">08</subfield><subfield code="r">2022-01-28 13:53:01 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">2731849-1380</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948840006381</subfield><subfield code="z">v.29:no.2(2020:April)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015098312211</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767948870006381</subfield><subfield code="z">v.27 2018</subfield><subfield code="p">01</subfield><subfield code="r">2018-03-15 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015099618640</subfield><subfield code="e">SOVR</subfield><subfield code="n">Bound without no.6</subfield><subfield code="7">231173895750006381</subfield><subfield code="z">v.28 no.1-5 2019</subfield><subfield code="p">01</subfield><subfield code="r">2022-01-28 09:50:20 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015038861541</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015038861541 ic 20210127</subfield><subfield code="7">23767949200006381</subfield><subfield code="z">v.5 1996</subfield><subfield code="p">01</subfield><subfield code="r">1997-04-03 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015036964495</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015036964495 ic 20210127</subfield><subfield code="7">23767949210006381</subfield><subfield code="z">v.4 1995</subfield><subfield code="p">01</subfield><subfield code="r">1996-05-10 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113556</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228589960006381</subfield><subfield code="z">v.32:no.6(2023:Dec.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113555</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228589970006381</subfield><subfield code="z">v.32:no.5(2023:Oct.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113554</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228589980006381</subfield><subfield code="z">v.32:no.4(2023:Aug.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015046265339</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015046265339 ic 20210127</subfield><subfield code="7">23767949180006381</subfield><subfield code="z">v.6 1997</subfield><subfield code="p">01</subfield><subfield code="r">1999-09-28 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="a">39015060977561</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015060977561 ic 20210127</subfield><subfield code="7">23767949090006381</subfield><subfield code="z">v.15 2006</subfield><subfield code="p">01</subfield><subfield code="r">2006-02-14 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015027110942</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015027110942 ic 20210127</subfield><subfield code="7">23767949250006381</subfield><subfield code="z">v.2 1993</subfield><subfield code="p">01</subfield><subfield code="r">1994-05-07 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015027149817</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015027149817 ic 20200723</subfield><subfield code="7">23767949230006381</subfield><subfield code="z">v.3 1994</subfield><subfield code="p">01</subfield><subfield code="r">1995-03-09 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSBD</subfield><subfield code="a">39015072603916</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015072603916 ic 20210127</subfield><subfield code="7">23767949070006381</subfield><subfield code="z">v.16 2007</subfield><subfield code="p">01</subfield><subfield code="r">2007-02-12 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113552</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590000006381</subfield><subfield code="z">v.32:no.2(2023:Apr.)</subfield><subfield code="p">08</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A113550</subfield><subfield code="e">SOVR</subfield><subfield code="7">231228590020006381</subfield><subfield code="z">v.31:no.6(2022:Dec.)</subfield><subfield code="p">08</subfield><subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015057338413</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015057338413 ic 20210127</subfield><subfield code="7">23767949120006381</subfield><subfield code="z">v.12 2003</subfield><subfield code="p">01</subfield><subfield code="r">2004-05-05 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015053942994</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015053942994 ic 20200828</subfield><subfield code="7">23767949140006381</subfield><subfield code="z">v.10 2001</subfield><subfield code="p">01</subfield><subfield code="r">2002-05-03 06:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">39015053932557</subfield><subfield code="e">SOVR</subfield><subfield code="u">mdp.39015053932557 ic 20201028</subfield><subfield code="7">23767949160006381</subfield><subfield code="z">v.8 1999</subfield><subfield code="p">01</subfield><subfield code="r">2002-04-04 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A30840</subfield><subfield code="e">SOVR</subfield><subfield code="7">231173897070006381</subfield><subfield code="z">v.30:no.2(2021:Apr.)</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">1</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield><subfield code="a">39015083670508</subfield><subfield code="e">SOVR</subfield><subfield code="7">23767949030006381</subfield><subfield code="z">v.19 2010</subfield><subfield code="p">01</subfield><subfield code="r">2010-02-11 05:59:00 US/Eastern</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A30844</subfield><subfield code="e">SOVR</subfield><subfield code="7">231173897030006381</subfield><subfield code="z">v.30:no.6(2021:Dec.)</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield><datafield tag="974" ind1=" " ind2=" "><subfield code="8">22767949280006381</subfield><subfield code="f">0</subfield><subfield code="t">ACQ</subfield><subfield code="c">SOVR</subfield><subfield code="m">ISSUE</subfield><subfield code="a">A30842</subfield><subfield code="e">SOVR</subfield><subfield code="7">231173897050006381</subfield><subfield code="z">v.30:no.4(2021:Aug.)</subfield><subfield code="h">SB 435 .A71</subfield><subfield code="d">SHAP</subfield><subfield code="b">SHAP</subfield></datafield></record></collection>
+<collection>  <record>
+  <leader>00000nas a2200289 a 4500</leader>
+  <controlfield tag="005">20200722183858.0</controlfield>
+  <controlfield tag="006">m        d</controlfield>
+  <controlfield tag="007">cr bn ---auaua</controlfield>
+  <controlfield tag="008">931217c19929999ilubr p       0    0eng d</controlfield>
+  <controlfield tag="001">990027318490106381</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiU)002731849MIU01</subfield>
+  </datafield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="a">sn 93026898</subfield>
+  </datafield>
+  <datafield tag="022" ind1=" " ind2=" ">
+    <subfield code="a">1542-2399</subfield>
+    <subfield code="0">http://worldcat.org/issn/1542-2399</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)ocm25376224</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">VXG</subfield>
+    <subfield code="c">VXG</subfield>
+    <subfield code="d">FUG</subfield>
+    <subfield code="d">WAU</subfield>
+    <subfield code="d">EYM</subfield>
+  </datafield>
+  <datafield tag="042" ind1=" " ind2=" ">
+    <subfield code="a">lcd</subfield>
+  </datafield>
+  <datafield tag="050" ind1="1" ind2="4">
+    <subfield code="a">SB435</subfield>
+    <subfield code="b">.A7</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Arborist news /</subfield>
+    <subfield code="c">International Society of Arboriculture.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Savoy, IL :</subfield>
+    <subfield code="b">The Society.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">v. :</subfield>
+    <subfield code="b">ill. ;</subfield>
+    <subfield code="c">28 cm</subfield>
+  </datafield>
+  <datafield tag="310" ind1=" " ind2=" ">
+    <subfield code="a">Bimonthly</subfield>
+  </datafield>
+  <datafield tag="362" ind1="1" ind2=" ">
+    <subfield code="a">Began with: Vol. 1, no. 1 (Feb. 1992).</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Description based on: Vol. 2, no. 3 (June 1993); title from cover.</subfield>
+  </datafield>
+  <datafield tag="610" ind1="2" ind2="0">
+    <subfield code="a">International Society of Arboriculture</subfield>
+    <subfield code="v">Periodicals.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/names/n86824788</subfield>
+    <subfield code="0">http://viaf.org/viaf/sourceID/LC|n86824788</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Arboriculture</subfield>
+    <subfield code="v">Periodicals.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh85006470</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Trees</subfield>
+    <subfield code="v">Periodicals.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh85137241</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">International Society of Arboriculture.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/names/n86824788</subfield>
+    <subfield code="0">http://viaf.org/viaf/sourceID/LC|n86824788</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="1">
+    <subfield code="3">12 months ago-</subfield>
+    <subfield code="z">Institutional password required for access to the International Society of Arboriculture online version; authentication required:</subfield>
+    <subfield code="u">https://apps.lib.umich.edu/pk/resource.php?002731849</subfield>
+    <subfield code="x">http://www.isa-arbor.com/Publications/Arborist-News</subfield>
+    <subfield code="m">International Society of Arboriculture</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="1">
+    <subfield code="3">Feb. 2002-12 months ago</subfield>
+    <subfield code="z">Access to archived issues via the International Society of Arboriculture online version:</subfield>
+    <subfield code="u">http://www.isa-arbor.com/Publications/Arborist-News#archived</subfield>
+    <subfield code="m">archived issues via the International Society of Arboriculture</subfield>
+  </datafield>
+  <datafield tag="997" ind1=" " ind2=" ">
+    <subfield code="a">MARS</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="c">lene-rdu MaintCorrEserial 20200722 ELEC</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="c">lene-rdu MaintCorrESerial 20180927 ELEC</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="c">lene-rdu AddVolSerial 20180521</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="c">sc5</subfield>
+  </datafield>
+  <datafield tag="958" ind1=" " ind2=" ">
+    <subfield code="a">MiU</subfield>
+  </datafield>
+  <datafield tag="959" ind1=" " ind2=" ">
+    <subfield code="a">(notis)ULAPJ0006</subfield>
+  </datafield>
+  <datafield tag="995" ind1=" " ind2=" ">
+    <subfield code="a">20</subfield>
+  </datafield>
+  <datafield tag="787" ind1="0" ind2=" ">
+    <subfield code="t">Birds</subfield>
+    <subfield code="w">811230624800006381</subfield>
+    <subfield code="i">Alma Collection</subfield>
+  </datafield>
+  <datafield tag="787" ind1="0" ind2=" ">
+    <subfield code="t">MRIO Top Level Collection</subfield>
+    <subfield code="w">811230624810006381</subfield>
+    <subfield code="i">Alma Collection</subfield>
+  </datafield>
+  <datafield tag="BIB" ind1=" " ind2=" ">
+    <subfield code="u">2021-08-17 11:36:20 US/Eastern</subfield>
+    <subfield code="c">2021-06-21 06:05:49 US/Eastern</subfield>
+    <subfield code="s">false</subfield>
+  </datafield>
+  <datafield tag="AVD" ind1="0" ind2=" ">
+    <subfield code="z">This is a Public Note</subfield>
+    <subfield code="l">This is a label</subfield>
+    <subfield code="d">2 file/s (Mixed)</subfield>
+    <subfield code="u">https://umich-psb.alma.exlibrisgroup.com/discovery/delivery/01UMICH_INST:FLINT/121230624780006381</subfield>
+  </datafield>
+  <datafield tag="E56" ind1=" " ind2=" ">
+    <subfield code="j">2021-06-23 18:18:09 US/Eastern</subfield>
+    <subfield code="m">archived issues via the International Society of Arboriculture</subfield>
+    <subfield code="p">System</subfield>
+    <subfield code="i">2021-06-23 18:17:59 US/Eastern</subfield>
+    <subfield code="u">https://na04-psb.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=531031051570006381&amp;Force_direct=true</subfield>
+    <subfield code="w">P2E_JOB</subfield>
+    <subfield code="g">531031051570006381</subfield>
+    <subfield code="x">UMAA proxy</subfield>
+    <subfield code="1">2021-06-23 22:17:59</subfield>
+    <subfield code="y">true</subfield>
+    <subfield code="l">ELEC</subfield>
+    <subfield code="t">static</subfield>
+    <subfield code="r">500443441</subfield>
+    <subfield code="6">521031051580006381</subfield>
+    <subfield code="v">https://umich.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?&amp;rfr_id=info:sid/primo.exlibrisgroup.com&amp;svc_dat=CTO?u.ignore_date_coverage=true?u.ignore_date_coverage=true&amp;rft.mms_id=990027318490106381</subfield>
+    <subfield code="z">Access to archived issues via the International Society of Arboriculture online version:</subfield>
+    <subfield code="s">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="e">http://www.isa-arbor.com/Publications/Arborist-News#archived</subfield>
+    <subfield code="8">531031051570006381</subfield>
+  </datafield>
+  <datafield tag="E56" ind1=" " ind2=" ">
+    <subfield code="j">2021-06-23 18:18:09 US/Eastern</subfield>
+    <subfield code="m">International Society of Arboriculture</subfield>
+    <subfield code="p">System</subfield>
+    <subfield code="i">2021-06-23 18:17:59 US/Eastern</subfield>
+    <subfield code="u">https://na04-psb.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=531031051590006381&amp;Force_direct=true</subfield>
+    <subfield code="w">P2E_JOB</subfield>
+    <subfield code="g">531031051590006381</subfield>
+    <subfield code="x">UMAA proxy</subfield>
+    <subfield code="1">2021-06-23 22:17:59</subfield>
+    <subfield code="y">true</subfield>
+    <subfield code="l">ELEC</subfield>
+    <subfield code="t">static</subfield>
+    <subfield code="r">500443441</subfield>
+    <subfield code="6">521031051600006381</subfield>
+    <subfield code="v">https://umich.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?&amp;rfr_id=info:sid/primo.exlibrisgroup.com&amp;svc_dat=CTO?u.ignore_date_coverage=true?u.ignore_date_coverage=true&amp;rft.mms_id=990027318490106381</subfield>
+    <subfield code="z">Institutional password required for access to the International Society of Arboriculture online version; authentication required:</subfield>
+    <subfield code="s">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="e">https://apps.lib.umich.edu/pk/resource.php?002731849</subfield>
+    <subfield code="8">531031051590006381</subfield>
+  </datafield>
+  <datafield tag="852" ind1="0" ind2=" ">
+    <subfield code="b">SHAP</subfield>
+    <subfield code="a">MiU</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="z">CURRENT ISSUES IN SERIAL SERVICES, 203 NORTH HATCHER</subfield>
+    <subfield code="z">MISSING: 24 no.1-2 2015, v.28 no.6 2019</subfield>
+    <subfield code="8">22767949280006381</subfield>
+  </datafield>
+  <datafield tag="866" ind1="3" ind2="2">
+    <subfield code="a">2-</subfield>
+    <subfield code="8">22767949280006381</subfield>
+  </datafield>
+  <datafield tag="866" ind1="3" ind2="2">
+    <subfield code="a">1993-</subfield>
+    <subfield code="8">22767949280006381</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113546</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590060006381</subfield>
+    <subfield code="z">v.31:no.2(2022:Apr.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015098302691</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948940006381</subfield>
+    <subfield code="z">v.26 2017</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2017-02-15 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015098283776</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948930006381</subfield>
+    <subfield code="z">v.25 2016</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2016-02-25 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113548</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590040006381</subfield>
+    <subfield code="z">v.31:no.4(2022:Aug.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015081678495</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948960006381</subfield>
+    <subfield code="z">v.24 no.3-6 2015</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2015-06-12 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113547</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590050006381</subfield>
+    <subfield code="z">v.31:no.3(2022:June)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113545</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590070006381</subfield>
+    <subfield code="z">v.31:no.1(2022:Feb.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="a">39015060977553</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015060977553 ic 20210127</subfield>
+    <subfield code="7">23767949100006381</subfield>
+    <subfield code="z">v.14 2005</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2005-08-09 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113549</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590030006381</subfield>
+    <subfield code="z">v.31:no.5(2022:Oct.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015090095483</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948970006381</subfield>
+    <subfield code="z">v.23 2014</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2014-02-07 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015090035273</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948990006381</subfield>
+    <subfield code="z">v.22 2013</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2013-03-15 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015089014933</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767949080006381</subfield>
+    <subfield code="z">v.17 2008</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2008-02-20 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015085229675</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767949060006381</subfield>
+    <subfield code="z">v.18 2009</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2009-02-16 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113551</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590010006381</subfield>
+    <subfield code="z">v.32:no.1(2023:Feb.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015055714276</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015055714276 ic 20210127</subfield>
+    <subfield code="7">23767949130006381</subfield>
+    <subfield code="z">v.11 2002</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2003-05-15 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015053932409</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015053932409 ic 20210127</subfield>
+    <subfield code="7">23767949150006381</subfield>
+    <subfield code="z">v.9 2000</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2002-04-04 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015046265354</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015046265354 ic 20210127</subfield>
+    <subfield code="7">23767949170006381</subfield>
+    <subfield code="z">v.7 1998</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">1999-09-28 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="a">39015060977546</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015060977546 ic 20210127</subfield>
+    <subfield code="7">23767949110006381</subfield>
+    <subfield code="z">v.13 2004</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2004-10-29 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015089014784</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767949020006381</subfield>
+    <subfield code="z">v.20 2011</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2011-02-21 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A30841</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231173897060006381</subfield>
+    <subfield code="z">v.30:no.3(2021:June)</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015090404529</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767949000006381</subfield>
+    <subfield code="z">v.21 2012</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2012-02-01 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A30843</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231173897040006381</subfield>
+    <subfield code="z">v.30:no.5(2021:Oct.)</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A30839</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231173897080006381</subfield>
+    <subfield code="z">v.30:no.1(2021:Feb.)</subfield>
+    <subfield code="r">2022-01-28 13:54:44 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1400</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948820006381</subfield>
+    <subfield code="z">v.29:no.4(2020:Aug.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1410</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948810006381</subfield>
+    <subfield code="z">v.29:no.5(2020:Oct.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1390</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948830006381</subfield>
+    <subfield code="z">v.29:no.3(2020:Jun.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113553</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228589990006381</subfield>
+    <subfield code="z">v.32:no.3(2023:June)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1350</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948850006381</subfield>
+    <subfield code="z">v.28 no.6(2019:Dec.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1370</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948860006381</subfield>
+    <subfield code="z">v.29:no.1(2020:Feb.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2020-02-27 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1420</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948800006381</subfield>
+    <subfield code="z">v.29:no.6(2020:Dec.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2022-01-28 13:53:01 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">2731849-1380</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948840006381</subfield>
+    <subfield code="z">v.29:no.2(2020:April)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015098312211</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767948870006381</subfield>
+    <subfield code="z">v.27 2018</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2018-03-15 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015099618640</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="n">Bound without no.6</subfield>
+    <subfield code="7">231173895750006381</subfield>
+    <subfield code="z">v.28 no.1-5 2019</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2022-01-28 09:50:20 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015038861541</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015038861541 ic 20210127</subfield>
+    <subfield code="7">23767949200006381</subfield>
+    <subfield code="z">v.5 1996</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">1997-04-03 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015036964495</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015036964495 ic 20210127</subfield>
+    <subfield code="7">23767949210006381</subfield>
+    <subfield code="z">v.4 1995</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">1996-05-10 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113556</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228589960006381</subfield>
+    <subfield code="z">v.32:no.6(2023:Dec.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113555</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228589970006381</subfield>
+    <subfield code="z">v.32:no.5(2023:Oct.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113554</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228589980006381</subfield>
+    <subfield code="z">v.32:no.4(2023:Aug.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015046265339</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015046265339 ic 20210127</subfield>
+    <subfield code="7">23767949180006381</subfield>
+    <subfield code="z">v.6 1997</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">1999-09-28 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="a">39015060977561</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015060977561 ic 20210127</subfield>
+    <subfield code="7">23767949090006381</subfield>
+    <subfield code="z">v.15 2006</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2006-02-14 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015027110942</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015027110942 ic 20210127</subfield>
+    <subfield code="7">23767949250006381</subfield>
+    <subfield code="z">v.2 1993</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">1994-05-07 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015027149817</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015027149817 ic 20200723</subfield>
+    <subfield code="7">23767949230006381</subfield>
+    <subfield code="z">v.3 1994</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">1995-03-09 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSBD</subfield>
+    <subfield code="a">39015072603916</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015072603916 ic 20210127</subfield>
+    <subfield code="7">23767949070006381</subfield>
+    <subfield code="z">v.16 2007</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2007-02-12 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113552</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590000006381</subfield>
+    <subfield code="z">v.32:no.2(2023:Apr.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A113550</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231228590020006381</subfield>
+    <subfield code="z">v.31:no.6(2022:Dec.)</subfield>
+    <subfield code="p">08</subfield>
+    <subfield code="r">2023-01-12 14:22:46 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015057338413</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015057338413 ic 20210127</subfield>
+    <subfield code="7">23767949120006381</subfield>
+    <subfield code="z">v.12 2003</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2004-05-05 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015053942994</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015053942994 ic 20200828</subfield>
+    <subfield code="7">23767949140006381</subfield>
+    <subfield code="z">v.10 2001</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2002-05-03 06:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">39015053932557</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="u">mdp.39015053932557 ic 20201028</subfield>
+    <subfield code="7">23767949160006381</subfield>
+    <subfield code="z">v.8 1999</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2002-04-04 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A30840</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231173897070006381</subfield>
+    <subfield code="z">v.30:no.2(2021:Apr.)</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="w">Recd w/Jnl.of Arboriculture (PO 11534126)</subfield>
+    <subfield code="a">39015083670508</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">23767949030006381</subfield>
+    <subfield code="z">v.19 2010</subfield>
+    <subfield code="p">01</subfield>
+    <subfield code="r">2010-02-11 05:59:00 US/Eastern</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A30844</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231173897030006381</subfield>
+    <subfield code="z">v.30:no.6(2021:Dec.)</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+  <datafield tag="974" ind1=" " ind2=" ">
+    <subfield code="8">22767949280006381</subfield>
+    <subfield code="f">0</subfield>
+    <subfield code="t">ACQ</subfield>
+    <subfield code="c">SOVR</subfield>
+    <subfield code="m">ISSUE</subfield>
+    <subfield code="a">A30842</subfield>
+    <subfield code="e">SOVR</subfield>
+    <subfield code="7">231173897050006381</subfield>
+    <subfield code="z">v.30:no.4(2021:Aug.)</subfield>
+    <subfield code="h">SB 435 .A71</subfield>
+    <subfield code="d">SHAP</subfield>
+    <subfield code="b">SHAP</subfield>
+  </datafield>
+</record>

--- a/umich_catalog_indexing/spec/traject/umich/digital_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/digital_holding_spec.rb
@@ -21,19 +21,9 @@ describe Traject::UMich::DigitalHolding do
       expect(subject.link).to eq("https://umich-psb.alma.exlibrisgroup.com/discovery/delivery/01UMICH_INST:UMICH/121230624780006381")
     end
   end
-  context "#note" do
-    it "returns the delivery description (i.e. the file type) and the z field" do
-      expect(subject.note).to eq("2 file/s (Mixed); This is a Public Note")
-    end
-  end
   context "#library" do
-    it "shows ELEC" do
-      expect(subject.library).to eq("ELEC")
-    end
-  end
-  context "#status" do
-    it "shows Available" do
-      expect(subject.status).to eq("Available")
+    it "shows ALMA_DIGITAL" do
+      expect(subject.library).to eq("ALMA_DIGITAL")
     end
   end
   context "#link_text" do
@@ -41,27 +31,31 @@ describe Traject::UMich::DigitalHolding do
       expect(subject.link_text).to eq("Available online")
     end
   end
-  context "#description" do
+  context "#label" do
     it "shows the label from subfield l" do
-      expect(subject.description).to eq("This is a label")
+      expect(subject.label).to eq("This is a label")
     end
   end
-  context "#finding_aid" do
-    it "is false" do
-      expect(subject.finding_aid).to eq(false)
+  context "#public_note" do
+    it "shows the public note from subfield z" do
+      expect(subject.public_note).to eq("This is a Public Note")
+    end
+  end
+  context "#delivery_description" do
+    it "show the delivery_description from subfield d" do
+      expect(subject.delivery_description).to eq("2 file/s (Mixed)")
     end
   end
   context "#to_h" do
     it "returns expected hash" do
       expect(subject.to_h).to eq( 
         {
-          finding_aid: false,
-          library: "ELEC",
+          library: "ALMA_DIGITAL",
           link: "https://umich-psb.alma.exlibrisgroup.com/discovery/delivery/01UMICH_INST:UMICH/121230624780006381",
           link_text: "Available online",
-          note: "2 file/s (Mixed); This is a Public Note",
-          status: "Available",
-          description: "This is a label"
+          delivery_description: "2 file/s (Mixed)",
+          label: "This is a label",
+          public_note: "This is a Public Note"
         }
       )
     end

--- a/umich_catalog_indexing/spec/traject/umich/digital_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/digital_holding_spec.rb
@@ -22,8 +22,8 @@ describe Traject::UMich::DigitalHolding do
     end
   end
   context "#note" do
-    it "returns the z field" do
-      expect(subject.note).to eq("This is a Public Note")
+    it "returns the delivery description (i.e. the file type) and the z field" do
+      expect(subject.note).to eq("2 file/s (Mixed); This is a Public Note")
     end
   end
   context "#library" do
@@ -42,8 +42,8 @@ describe Traject::UMich::DigitalHolding do
     end
   end
   context "#description" do
-    it "shows empty string" do
-      expect(subject.description).to eq("")
+    it "shows the label from subfield l" do
+      expect(subject.description).to eq("This is a label")
     end
   end
   context "#finding_aid" do
@@ -59,9 +59,9 @@ describe Traject::UMich::DigitalHolding do
           library: "ELEC",
           link: "https://umich-psb.alma.exlibrisgroup.com/discovery/delivery/01UMICH_INST:UMICH/121230624780006381",
           link_text: "Available online",
-          note: "This is a Public Note",
+          note: "2 file/s (Mixed); This is a Public Note",
           status: "Available",
-          description: ""
+          description: "This is a label"
         }
       )
     end


### PR DESCRIPTION
After the meeting today with the Alma Digital team, it was decided that Alma digital items should use the "label" for the description" and the "file types plus the public note" for the "source". 

I'm going to use this opportunity to have an Alma Digital item look different than an Electronic item so that I have more freedom to pass different fields in the future and so the data model is clearer. 