### PR TITLE
fix: solr credentials not required

### DIFF
--- a/umich_catalog_indexing/lib/jobs/delete_id_getter.rb
+++ b/umich_catalog_indexing/lib/jobs/delete_id_getter.rb
@@ -33,8 +33,8 @@ module Jobs
     end
     def auth
       {
-        username: ENV.fetch("SOLR_USER"),
-        password: ENV.fetch("SOLR_PASSWORD")
+        username: ENV.fetch("SOLR_USER", nil),
+        password: ENV.fetch("SOLR_PASSWORD", nil)
       }
     end
   end


### PR DESCRIPTION
For the `DeleteIt` job, `SOLR_USER` and `SOLR_PASSWORD` used to be required. Now they are not required.