### PR TITLE
Update HLB code to ignore non-callnumber-lookings stuff

### DIFF
--- a/umich_catalog_indexing/indexers/callnumbers.rb
+++ b/umich_catalog_indexing/indexers/callnumbers.rb
@@ -134,3 +134,23 @@ to_field 'callnoletters', extract_marc('852hij:050ab:090ab', :first => true) do 
   acc.select! { |cn| looks_like_lc?(cn) }
   acc.replace [extract_letters(acc.first)].compact
 end
+
+### High Level Browse ###
+require 'high_level_browse'
+
+hlb = HighLevelBrowse.load(dir: Pathname.new(__dir__) + "../lib/translation_maps")
+to_field 'hlb3Delimited', extract_marc('050ab:082a:090ab:099a:086a:086z:852|0*|hij') do |rec, acc, context|
+  acc.select! { |cn| looks_like_lc?(cn) }
+  acc.map! { |c| hlb[c] }
+  acc.compact!
+  acc.uniq!
+  acc.flatten!(1)
+
+  # Get the individual conmponents and stash them
+  components = acc.flatten.to_a.uniq
+  context.output_hash['hlb3'] = components unless components.empty?
+
+  # Turn them into pipe-delimited strings
+  acc.map! { |c| c.to_a.join(' | ') }
+end
+

--- a/umich_catalog_indexing/indexers/umich.rb
+++ b/umich_catalog_indexing/indexers/umich.rb
@@ -62,29 +62,6 @@ to_field 'building', extract_marc('852bc:971a') do |rec, acc|
 end
 
 
-##mrio: 2023-08-03 taking this out because indexing is hanging on this.
-### High Level Browse ###
-#require 'high_level_browse'
-
-#hlb = HighLevelBrowse.load(dir: Pathname.new(__dir__) + "../lib/translation_maps")
-
-##to_field 'hlb3Delimited', extract_marc('050ab:082a:090ab:099|*0|a:086a:086z:852|0*|hij') do |rec, acc, context|
-
-#to_field 'hlb3Delimited', extract_marc('050ab:082a:090ab:099a:086a:086z:852|0*|hij') do |rec, acc, context|
-  #acc.map! { |c| hlb[c] }
-  #acc.compact!
-  #acc.uniq!
-  #acc.flatten!(1)
-
-  ## Get the individual conmponents and stash them
-  #components = acc.flatten.to_a.uniq
-  #context.output_hash['hlb3'] = components unless components.empty?
-
-  ## Turn them into pipe-delimited strings
-  #acc.map! { |c| c.to_a.join(' | ') }
-#end
-
-
 # Apply Best Bets
 require 'best_bets'
 


### PR DESCRIPTION
HLB was hanging on a few new records with "callnumbers" from less-commong fields that weren't close to being callnumbers (e.g., "TheBeeorLiteraryWeeklyIntelligencer17911793volume3").

This should be taken care of by the HLB gem itself, which is due for a new release given the URL change anyway. 

In the meantime, this is addressed by doing the following:

* Move the HLB code to the `callnumber.rb` indexing code, where it belongs
* Update that code with a line to `acc.select! { |cn| looks_like_lc?(cn) }`