### PR TITLE
Use correct field 'author_browse_terms'

### DIFF
--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -165,7 +165,7 @@ def valid_author_700?(field)
   has_t = !field['t'].nil?
   (ind2_blank and !has_t) or (ind2_2 and has_t)
 end
-to_field "author_authoritative_browse" do |rec, acc, _context|
+to_field "author_browse_terms" do |rec, acc, _context|
   authors = []
   author_7xx.each_matching_line(rec) do |field, spec, extractor|
     if valid_author_700?(field)


### PR DESCRIPTION
I've given up for the moment on fully "fixing" all the author stuff -- I need to do a deeper dive into the stuff we're
getting from HT and via the Alma electronic resources, 'cause I'm getting some weird stuff.

Anyway, this does nothing but change the name of the field to `author_browse_terms`, which reflects what the solr config is actually expecting. 