### PR TITLE
Change tofield("allfields") to include 880s

### DIFF
--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -63,7 +63,7 @@ def record_is_umich(r, context)
   return false
 end
 
-to_field "allfields", extract_all_marc_values(to: '850') do |r, acc|
+to_field "allfields", extract_all_marc_values(to: '880') do |r, acc|
   acc.replace [acc.join(' ')] # turn it into a single string
 end
 


### PR DESCRIPTION
The definition of `allfields` was only going up to include 850s, so we missed all the 880s with the vernacular text in them. This is...unforgivable. The git log only goes back to Feb 2022 'cause that's when there was a big merge, but I'm sure it has been that way for-freaking-ever. 