### PR TITLE
Libsearch 923 eresource public notes

### DIFF
--- a/umich_catalog_indexing/lib/umich_traject.rb
+++ b/umich_catalog_indexing/lib/umich_traject.rb
@@ -1,12 +1,13 @@
-require 'umich_traject/building_map'
-require 'umich_traject/location_map'
-require 'umich_traject/floor_location'
-require 'umich_traject/lib_loc_info'
+require "umich_traject/building_map"
+require "umich_traject/location_map"
+require "umich_traject/floor_location"
+require "umich_traject/lib_loc_info"
 
-require 'umich_traject/enumcron_sorter'
-require 'umich_traject/holdings'
-require 'umich_traject/digital_holding'
-require 'umich_traject/physical_holding'
-require 'umich_traject/physical_item'
+require "umich_traject/enumcron_sorter"
+require "umich_traject/holdings"
+require "umich_traject/digital_holding"
+require "umich_traject/physical_holding"
+require "umich_traject/physical_item"
+require "umich_traject/electronic_holding"
 
-UMich::FloorLocation.configure('lib/translation_maps/umich/floor_locations.json')
+UMich::FloorLocation.configure("lib/translation_maps/umich/floor_locations.json")

--- a/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
@@ -64,7 +64,7 @@ module Traject
           collection_name,
           authentication_note,
           public_note
-        ].flatten.map do |x|
+        ].flatten.compact.map do |x|
           x.strip.sub(/\p{P}$/, "").sub(/$/, ".")
         end.join(" ")
       end
@@ -82,18 +82,21 @@ module Traject
       end
 
       def to_h
-        {
-          library: library,
-          link: link,
-          link_text: link_text,
-          institution_codes: institution_codes,
-          interface_name: interface_name,
-          collection_name: collection_name,
-          authentication_note: authentication_note,
-          public_note: public_note,
-          note: note,
-          finding_aid: finding_aid
-        }
+        [
+          "library",
+          "link",
+          "link_text",
+          "link_campus",
+          "interface_name",
+          "collection_name",
+          "authentication_note",
+          "public_note",
+          "note",
+          "finding_aid",
+          "status"
+        ].map do |x|
+          [x, public_send(x)]
+        end.to_h
       end
 
       def _alma_campuses

--- a/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
@@ -10,23 +10,24 @@ module Traject
       end
 
       def link
-        code_map = {
-          "ann_arbor" => "UMAA",
-          "flint" => "UMFL"
-        }
-        URI::DEFAULT_PARSER.escape(@e56["u"].sub("openurl", "openurl-#{code_map[link_campus]}"))
+        code = (_alma_campuses.count == 1 && _alma_campuses.first == "UMFL") ? "UMFL" : "UMAA"
+        URI::DEFAULT_PARSER.escape(@e56["u"].sub("openurl", "openurl-#{code}"))
       end
 
       def link_text
         "Available online"
       end
 
-      def link_campus
+      def campuses
+        inst_code_map = {
+          "UMAA" => "ann_arbor",
+          "UMFL" => "flint"
+        }
         # return flint when it's the only campus
-        if _alma_campuses.count == 1 && _alma_campuses.first == "UMFL"
-          "flint"
+        if _alma_campuses.empty?
+          inst_code_map.values
         else
-          "ann_arbor"
+          _alma_campuses.map { |code| inst_code_map[code] }
         end
       end
 
@@ -86,7 +87,7 @@ module Traject
           "library",
           "link",
           "link_text",
-          "link_campus",
+          "campuses",
           "interface_name",
           "collection_name",
           "authentication_note",

--- a/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
@@ -1,0 +1,104 @@
+module Traject
+  module UMich
+    class ElectronicHolding
+      def initialize(e56)
+        @e56 = e56
+      end
+
+      def library
+        "ELEC"
+      end
+
+      def link
+        code_map = {
+          "ann_arbor" => "UMAA",
+          "flint" => "UMFL"
+        }
+        URI::DEFAULT_PARSER.escape(@e56["u"].sub("openurl", "openurl-#{code_map[link_campus]}"))
+      end
+
+      def link_text
+        "Available online"
+      end
+
+      def link_campus
+        # return flint when it's the only campus
+        if _alma_campuses.count == 1 && _alma_campuses.first == "UMFL"
+          "flint"
+        else
+          "ann_arbor"
+        end
+      end
+
+      def institution_codes
+        inst_code_map = {
+          "UMAA" => "MIU",
+          "UMFL" => "MIFLIC"
+        }
+        if _alma_campuses.empty?
+          inst_code_map.values
+        else
+          _alma_campuses.map { |code| inst_code_map[code] }
+        end
+      end
+
+      def interface_name
+        @e56["m"]
+      end
+
+      def collection_name
+        @e56["n"]
+      end
+
+      def authentication_note
+        @e56.subfields.filter_map { |x| x.value if x.code == "4" }
+      end
+
+      def public_note
+        @e56["z"]
+      end
+
+      def note
+        [
+          interface_name,
+          collection_name,
+          authentication_note,
+          public_note
+        ].flatten.map do |x|
+          x.strip.sub(/\p{P}$/, "").sub(/$/, ".")
+        end.join(" ")
+      end
+
+      def status
+        @e56["s"]
+      end
+
+      def description
+        @e56["3"]
+      end
+
+      def finding_aid
+        false
+      end
+
+      def to_h
+        {
+          library: library,
+          link: link,
+          link_text: link_text,
+          institution_codes: institution_codes,
+          interface_name: interface_name,
+          collection_name: collection_name,
+          authentication_note: authentication_note,
+          public_note: public_note,
+          note: note,
+          finding_aid: finding_aid
+        }
+      end
+
+      def _alma_campuses
+        @e56.subfields.filter_map { |x| x.value if x.code == "c" }
+      end
+    end
+  end
+end

--- a/umich_catalog_indexing/lib/umich_traject/holdings.rb
+++ b/umich_catalog_indexing/lib/umich_traject/holdings.rb
@@ -1,17 +1,20 @@
 module Traject
   module UMich
     class Holdings
-      def initialize(record, context, libLocInfo, floor_locator, hathifiles)
+      def initialize(record, context, lib_loc_info, floor_locator, hathifiles)
         @record = record
         @context = context
-        @libLocInfo = libLocInfo
+        @lib_loc_info = lib_loc_info
         @floor_locator = floor_locator
         @hathifiles = hathifiles
       end
 
       attr_reader :context
+      attr_reader :lib_loc_info
 
-      attr_reader :libLocInfo
+      def libLocInfo
+        lib_loc_info
+      end
 
       def enumcronSort a, b
         a[:sortstring] <=> b[:sortstring]

--- a/umich_catalog_indexing/spec/fixtures/e_resource.xml
+++ b/umich_catalog_indexing/spec/fixtures/e_resource.xml
@@ -1,0 +1,161 @@
+<record xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd" xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <leader>01619nam  2200481 a 4500</leader>
+  <controlfield tag="001">99187438120106381</controlfield>
+  <controlfield tag="005">20230120012551.0</controlfield>
+  <controlfield tag="006">m     o  d |</controlfield>
+  <controlfield tag="007">cr -n---------</controlfield>
+  <controlfield tag="008">860314s1987    flua    ob    001 0 eng d</controlfield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="z">86003525</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">0-323-15582-0</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)2670000000286104</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EBL)1180583</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)850150173</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(SSID)ssj0001398845</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(PQKBManifestationID)11798862</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(PQKBTitleCode)TC0001398845</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(PQKBWorkID)11465173</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(PQKB)10069204</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC1180583</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)992670000000286104</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MiAaPQ</subfield>
+    <subfield code="c">MiAaPQ</subfield>
+    <subfield code="d">MiAaPQ</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">eng</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">QC173.4.C65</subfield>
+    <subfield code="b">D38 1987</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="0">
+    <subfield code="a">530.4</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Dattagupta, S.</subfield>
+    <subfield code="q">(Sushanta),</subfield>
+    <subfield code="d">1947-</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/names/n83125519</subfield>
+    <subfield code="0">http://viaf.org/viaf/sourceID/LC|n83125519</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Relaxation phenomena in condensed matter physics</subfield>
+    <subfield code="h">[electronic resource] /</subfield>
+    <subfield code="c">Sushanta Dattagupta.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Orlando :</subfield>
+    <subfield code="b">Academic Press,</subfield>
+    <subfield code="c">1987.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (326 p.)</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Description based upon print version of record.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">Relaxation Phenomena in condensed Matter Physics</subfield>
+  </datafield>
+  <datafield tag="546" ind1=" " ind2=" ">
+    <subfield code="a">English</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references and index.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">pt. a. Spectroscopy techniques and associated correlation functions pt. b. Stochastic modeling of correlation functions.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Condensed matter</subfield>
+    <subfield code="x">Optical properties.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh85030765</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Relaxation phenomena.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh85112503</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Spectrum analysis.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh85126423</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Stochastic processes.</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/subjects/sh85128181</subfield>
+  </datafield>
+  <datafield tag="776" ind1=" " ind2=" ">
+    <subfield code="z">0-12-203610-7</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">BOOK</subfield>
+  </datafield>
+  <datafield tag="BIB" ind1=" " ind2=" ">
+    <subfield code="u">2023-01-21 10:27:48 US/Eastern</subfield>
+    <subfield code="c">2012-12-30 03:23:59 US/Eastern</subfield>
+    <subfield code="s">false</subfield>
+  </datafield>
+  <datafield tag="E56" ind1=" " ind2=" ">
+    <subfield code="4">Access to the Elsevier ScienceDirect eBook - Physics and Astronomy (Legacy 1) online version restricted; authentication may be required.</subfield>
+    <subfield code="4">Elsevier ScienceDirect access restricted; authentication may be required.</subfield>
+    <subfield code="m">Elsevier ScienceDirect;</subfield>
+    <subfield code="n">Elsevier SD eBook - Physics and Astronomy?</subfield>
+    <subfield code="t">param</subfield>
+    <subfield code="u">https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=531162080550006381&amp;Force_direct=true</subfield>
+    <subfield code="a">2021-10-15 12:52:25</subfield>
+    <subfield code="v">https://umich.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?&amp;rfr_id=info:sid/primo.exlibrisgroup.com&amp;svc_dat=CTO?u.ignore_date_coverage=true?u.ignore_date_coverage=true&amp;rft.mms_id=99187438120106381</subfield>
+    <subfield code="q">true</subfield>
+    <subfield code="s">Available</subfield>
+    <subfield code="z">Public note:</subfield>
+    <subfield code="3">Description</subfield>
+    <subfield code="8">531162080550006381</subfield>
+  </datafield>
+  <datafield tag="E56" ind1=" " ind2=" ">
+    <subfield code="4">Elsevier ScienceDirect access restricted; authentication may be required.</subfield>
+    <subfield code="m">Elsevier ScienceDirect</subfield>
+    <subfield code="n">Elsevier ScienceDirect Books Complete</subfield>
+    <subfield code="t">param</subfield>
+    <subfield code="u">https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=531151073610006381&amp;Force_direct=true</subfield>
+    <subfield code="a">2021-08-06 20:35:21</subfield>
+    <subfield code="v">https://umich.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl?&amp;rfr_id=info:sid/primo.exlibrisgroup.com&amp;svc_dat=CTO?u.ignore_date_coverage=true?u.ignore_date_coverage=true&amp;rft.mms_id=99187438120106381</subfield>
+    <subfield code="q">true</subfield>
+    <subfield code="s">Available</subfield>
+    <subfield code="8">531151073610006381</subfield>
+  </datafield>
+</record>

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -7,10 +7,10 @@ describe "umich_alma" do
     end
   end
   let(:hurdy_gurdy) do
-    get_record('./spec/fixtures/hurdy_gurdy.xml')
+    get_record("./spec/fixtures/hurdy_gurdy.xml")
   end
   let(:arborist) do
-    get_record('./spec/fixtures/arborist.xml')
+    get_record("./spec/fixtures/arborist.xml")
   end
   let(:indexer) do
     Traject::Indexer.new do
@@ -21,111 +21,113 @@ describe "umich_alma" do
   let(:expected_arborist) do
     [
       {
-         "finding_aid" => false,
-         "interface_name"=> "archived issues via the International Society of Arboriculture",
-         "library"=>"ELEC",
-         "link"=>
+        "finding_aid" => false,
+        "interface_name" => "archived issues via the International Society of Arboriculture",
+        "library" => "ELEC",
+        "link" =>
           "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051570006381&Force_direct=true",
-         "link_text"=>"Available online",
-         "note"=> "Access to archived issues via the International Society of Arboriculture online version:",
-         "status"=>"Available"},
-        {"finding_aid"=>false,
-         "interface_name"=>"International Society of Arboriculture",
-         "library"=>"ELEC",
-         "link"=>
-          "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051590006381&Force_direct=true",
-         "link_text"=>"Available online",
-         "note"=>
-          "Institutional password required for access to the International Society of Arboriculture online version; authentication required:",
-         "status"=>"Available"},
-        {"callnumber"=>"SB 435 .A71",
-         "display_name"=>"Shapiro Science Oversize Stacks - 4th floor",
-         "floor_location"=>"",
-         "hol_mmsid"=>"22767949280006381",
-         "info_link"=>"http://lib.umich.edu/locations-and-hours/shapiro-library",
-         "items"=>
-          [
-             {"barcode"=>"A30842",        
-             "callnumber"=>"SB 435 .A71", 
-             "can_reserve"=>false, 
-             "description"=>"v.30:no.4(2021:Aug.)",
-             "display_name"=>"Shapiro Science Oversize Stacks - 4th floor",
-             "fulfillment_unit"=>"General",
-             "location_type"=>"OPEN",
-             "info_link"=>"http://lib.umich.edu/locations-and-hours/shapiro-library",
-            "inventory_number"=>nil,    
-            "item_id"=>"231173897050006381",
-            "item_policy"=>nil,
-            "library"=>"SHAP",
-            "location"=>"SOVR",
-            "material_type"=>"ISSUE",
-            "permanent_library"=>"SHAP",
-            "permanent_location"=>"SOVR",
-            "process_type"=>"ACQ",
-            "public_note"=>nil,
-            "record_has_finding_aid"=>false,
-            "temp_location"=>false},
-          {"barcode"=>"A113546",
-            "callnumber"=>"SB 435 .A71",
-            "can_reserve"=>false,
-            "description"=>"v.31:no.2(2022:Apr.)",
-            "display_name"=>"Shapiro Science Oversize Stacks - 4th floor",
-            "fulfillment_unit"=>"General",
-            "location_type"=>"OPEN",
-            "info_link"=>"http://lib.umich.edu/locations-and-hours/shapiro-library",
-            "inventory_number"=>nil,
-            "item_id"=>"231228590060006381",
-            "item_policy"=>"08",
-            "library"=>"SHAP",
-            "location"=>"SOVR",
-            "material_type"=>"ISSUE",
-            "permanent_library"=>"SHAP",
-            "permanent_location"=>"SOVR",
-            "process_type"=>nil,
-            "public_note"=>nil,
-            "record_has_finding_aid"=>false,
-            "temp_location"=>false}],
-            "library"=>"SHAP",
-            "location"=>"SOVR",
-            "public_note"=>"CURRENT ISSUES IN SERIAL SERVICES, 203 NORTH HATCHER",
-            "record_has_finding_aid"=>false,
-            "summary_holdings"=>"2- : 1993-"}]
-
+        "link_text" => "Available online",
+        "note" => "Access to archived issues via the International Society of Arboriculture online version:",
+        "status" => "Available"
+      },
+      {"finding_aid" => false,
+       "interface_name" => "International Society of Arboriculture",
+       "library" => "ELEC",
+       "link" =>
+        "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051590006381&Force_direct=true",
+       "link_text" => "Available online",
+       "note" =>
+        "Institutional password required for access to the International Society of Arboriculture online version; authentication required:",
+       "status" => "Available"},
+      {"callnumber" => "SB 435 .A71",
+       "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
+       "floor_location" => "",
+       "hol_mmsid" => "22767949280006381",
+       "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
+       "items" =>
+        [
+          {"barcode" => "A30842",
+           "callnumber" => "SB 435 .A71",
+           "can_reserve" => false,
+           "description" => "v.30:no.4(2021:Aug.)",
+           "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
+           "fulfillment_unit" => "General",
+           "location_type" => "OPEN",
+           "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
+           "inventory_number" => nil,
+           "item_id" => "231173897050006381",
+           "item_policy" => nil,
+           "library" => "SHAP",
+           "location" => "SOVR",
+           "material_type" => "ISSUE",
+           "permanent_library" => "SHAP",
+           "permanent_location" => "SOVR",
+           "process_type" => "ACQ",
+           "public_note" => nil,
+           "record_has_finding_aid" => false,
+           "temp_location" => false},
+          {"barcode" => "A113546",
+           "callnumber" => "SB 435 .A71",
+           "can_reserve" => false,
+           "description" => "v.31:no.2(2022:Apr.)",
+           "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
+           "fulfillment_unit" => "General",
+           "location_type" => "OPEN",
+           "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
+           "inventory_number" => nil,
+           "item_id" => "231228590060006381",
+           "item_policy" => "08",
+           "library" => "SHAP",
+           "location" => "SOVR",
+           "material_type" => "ISSUE",
+           "permanent_library" => "SHAP",
+           "permanent_location" => "SOVR",
+           "process_type" => nil,
+           "public_note" => nil,
+           "record_has_finding_aid" => false,
+           "temp_location" => false}
+        ],
+       "library" => "SHAP",
+       "location" => "SOVR",
+       "public_note" => "CURRENT ISSUES IN SERIAL SERVICES, 203 NORTH HATCHER",
+       "record_has_finding_aid" => false,
+       "summary_holdings" => "2- : 1993-"}
+    ]
   end
   let(:expected_hurdy_gurdy) do
-    [{"callnumber"=>"ML760 .P18",
-         "display_name"=>"Music",
-         "floor_location"=>"",
-         "hol_mmsid"=>"22744541740006381",
-         "info_link"=>"http://lib.umich.edu/locations-and-hours/music-library",
-         "items"=>
+    [{"callnumber" => "ML760 .P18",
+      "display_name" => "Music",
+      "floor_location" => "",
+      "hol_mmsid" => "22744541740006381",
+      "info_link" => "http://lib.umich.edu/locations-and-hours/music-library",
+      "items" =>
           [
-            {"barcode"=>"39015009714562",
-            "callnumber"=>"ML760 .P18",
-            "can_reserve"=>false,
-            "description"=>nil,
-            "display_name"=>"Music",
-            "fulfillment_unit"=>"General",
-            "location_type"=>"OPEN",
-            "info_link"=>"http://lib.umich.edu/locations-and-hours/music-library",
-            "inventory_number"=>nil,
-            "item_id"=>"23744541730006381",
-            "item_policy"=>"01",
-            "library"=>"MUSIC",
-            "location"=>"NONE",
-            "material_type"=>"BOOK",
-            "permanent_library"=>"MUSIC",
-            "permanent_location"=>"NONE",
-            "process_type"=>nil,
-            "public_note"=>nil,
-            "record_has_finding_aid"=>false,
-            "temp_location"=>false}],
-         "library"=>"MUSIC",
-         "location"=>"NONE",
-         "public_note"=>nil,
-         "record_has_finding_aid"=>false,
-         "summary_holdings"=>nil}
-    ]
+            {"barcode" => "39015009714562",
+             "callnumber" => "ML760 .P18",
+             "can_reserve" => false,
+             "description" => nil,
+             "display_name" => "Music",
+             "fulfillment_unit" => "General",
+             "location_type" => "OPEN",
+             "info_link" => "http://lib.umich.edu/locations-and-hours/music-library",
+             "inventory_number" => nil,
+             "item_id" => "23744541730006381",
+             "item_policy" => "01",
+             "library" => "MUSIC",
+             "location" => "NONE",
+             "material_type" => "BOOK",
+             "permanent_library" => "MUSIC",
+             "permanent_location" => "NONE",
+             "process_type" => nil,
+             "public_note" => nil,
+             "record_has_finding_aid" => false,
+             "temp_location" => false}
+          ],
+      "library" => "MUSIC",
+      "location" => "NONE",
+      "public_note" => nil,
+      "record_has_finding_aid" => false,
+      "summary_holdings" => nil}]
   end
   before(:each) do
     @record = nil
@@ -135,8 +137,8 @@ describe "umich_alma" do
   end
   it "has expected physical hol" do
     @record = hurdy_gurdy
-    #item_policy = @record["974"].subfields.find{|s| s.code == "p" }
-    #item_policy.value = "08"
+    # item_policy = @record["974"].subfields.find{|s| s.code == "p" }
+    # item_policy.value = "08"
     hol = JSON.parse(subject["hol"].first)
     expect(hol).to eq(expected_hurdy_gurdy)
   end

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -21,77 +21,95 @@ describe "umich_alma" do
   let(:expected_arborist) do
     [
       {
-        "finding_aid" => false,
-        "interface_name" => "archived issues via the International Society of Arboriculture",
         "library" => "ELEC",
         "link" =>
           "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051570006381&Force_direct=true",
         "link_text" => "Available online",
-        "note" => "Access to archived issues via the International Society of Arboriculture online version:",
-        "status" => "Available"
+        "link_campus" => "ann_arbor",
+        "interface_name" => "archived issues via the International Society of Arboriculture",
+        "public_note" => "Access to archived issues via the International Society of Arboriculture online version:",
+        "note" => "archived issues via the International Society of Arboriculture. Access to archived issues via the International Society of Arboriculture online version.",
+        "status" => "Available",
+
+        "finding_aid" => false,
+        "authentication_note" => [],
+        "collection_name" => nil
       },
-      {"finding_aid" => false,
-       "interface_name" => "International Society of Arboriculture",
-       "library" => "ELEC",
-       "link" =>
+      {
+        "finding_aid" => false,
+        "interface_name" => "International Society of Arboriculture",
+        "library" => "ELEC",
+        "link" =>
         "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051590006381&Force_direct=true",
-       "link_text" => "Available online",
-       "note" =>
+        "link_text" => "Available online",
+        "link_campus" => "ann_arbor",
+        "public_note" =>
         "Institutional password required for access to the International Society of Arboriculture online version; authentication required:",
-       "status" => "Available"},
-      {"callnumber" => "SB 435 .A71",
-       "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
-       "floor_location" => "",
-       "hol_mmsid" => "22767949280006381",
-       "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
-       "items" =>
+        "note" =>
+        "International Society of Arboriculture. Institutional password required for access to the International Society of Arboriculture online version; authentication required.",
+        "status" => "Available",
+        "authentication_note" => [],
+        "collection_name" => nil
+      },
+      {
+        "callnumber" => "SB 435 .A71",
+        "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
+        "floor_location" => "",
+        "hol_mmsid" => "22767949280006381",
+        "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
+        "items" =>
         [
-          {"barcode" => "A30842",
-           "callnumber" => "SB 435 .A71",
-           "can_reserve" => false,
-           "description" => "v.30:no.4(2021:Aug.)",
-           "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
-           "fulfillment_unit" => "General",
-           "location_type" => "OPEN",
-           "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
-           "inventory_number" => nil,
-           "item_id" => "231173897050006381",
-           "item_policy" => nil,
-           "library" => "SHAP",
-           "location" => "SOVR",
-           "material_type" => "ISSUE",
-           "permanent_library" => "SHAP",
-           "permanent_location" => "SOVR",
-           "process_type" => "ACQ",
-           "public_note" => nil,
-           "record_has_finding_aid" => false,
-           "temp_location" => false},
-          {"barcode" => "A113546",
-           "callnumber" => "SB 435 .A71",
-           "can_reserve" => false,
-           "description" => "v.31:no.2(2022:Apr.)",
-           "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
-           "fulfillment_unit" => "General",
-           "location_type" => "OPEN",
-           "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
-           "inventory_number" => nil,
-           "item_id" => "231228590060006381",
-           "item_policy" => "08",
-           "library" => "SHAP",
-           "location" => "SOVR",
-           "material_type" => "ISSUE",
-           "permanent_library" => "SHAP",
-           "permanent_location" => "SOVR",
-           "process_type" => nil,
-           "public_note" => nil,
-           "record_has_finding_aid" => false,
-           "temp_location" => false}
+          {
+            "barcode" => "A30842",
+            "callnumber" => "SB 435 .A71",
+            "can_reserve" => false,
+            "description" => "v.30:no.4(2021:Aug.)",
+            "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
+            "fulfillment_unit" => "General",
+            "location_type" => "OPEN",
+            "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
+            "inventory_number" => nil,
+            "item_id" => "231173897050006381",
+            "item_policy" => nil,
+            "library" => "SHAP",
+            "location" => "SOVR",
+            "material_type" => "ISSUE",
+            "permanent_library" => "SHAP",
+            "permanent_location" => "SOVR",
+            "process_type" => "ACQ",
+            "public_note" => nil,
+            "record_has_finding_aid" => false,
+            "temp_location" => false
+          },
+          {
+            "barcode" => "A113546",
+            "callnumber" => "SB 435 .A71",
+            "can_reserve" => false,
+            "description" => "v.31:no.2(2022:Apr.)",
+            "display_name" => "Shapiro Science Oversize Stacks - 4th floor",
+            "fulfillment_unit" => "General",
+            "location_type" => "OPEN",
+            "info_link" => "http://lib.umich.edu/locations-and-hours/shapiro-library",
+            "inventory_number" => nil,
+            "item_id" => "231228590060006381",
+            "item_policy" => "08",
+            "library" => "SHAP",
+            "location" => "SOVR",
+            "material_type" => "ISSUE",
+            "permanent_library" => "SHAP",
+            "permanent_location" => "SOVR",
+            "process_type" => nil,
+            "public_note" => nil,
+            "record_has_finding_aid" => false,
+            "temp_location" => false
+          }
         ],
-       "library" => "SHAP",
-       "location" => "SOVR",
-       "public_note" => "CURRENT ISSUES IN SERIAL SERVICES, 203 NORTH HATCHER",
-       "record_has_finding_aid" => false,
-       "summary_holdings" => "2- : 1993-"}
+        "library" => "SHAP",
+        "location" => "SOVR",
+        "public_note" => "CURRENT ISSUES IN SERIAL SERVICES, 203 NORTH HATCHER",
+        "record_has_finding_aid" => false,
+        "summary_holdings" => "2- : 1993-"
+      }
     ]
   end
   let(:expected_hurdy_gurdy) do

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -25,7 +25,7 @@ describe "umich_alma" do
         "link" =>
           "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051570006381&Force_direct=true",
         "link_text" => "Available online",
-        "link_campus" => "ann_arbor",
+        "campuses" => ["ann_arbor", "flint"],
         "interface_name" => "archived issues via the International Society of Arboriculture",
         "public_note" => "Access to archived issues via the International Society of Arboriculture online version:",
         "note" => "archived issues via the International Society of Arboriculture. Access to archived issues via the International Society of Arboriculture online version.",
@@ -42,7 +42,7 @@ describe "umich_alma" do
         "link" =>
         "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051590006381&Force_direct=true",
         "link_text" => "Available online",
-        "link_campus" => "ann_arbor",
+        "campuses" => ["ann_arbor", "flint"],
         "public_note" =>
         "Institutional password required for access to the International Society of Arboriculture online version; authentication required:",
         "note" =>

--- a/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
@@ -134,16 +134,17 @@ describe Traject::UMich::ElectronicHolding do
       s = subject
       expect(s.to_h).to eq(
         {
-          library: s.library,
-          link: s.link,
-          link_text: s.link_text,
-          institution_codes: s.institution_codes,
-          interface_name: s.interface_name,
-          collection_name: s.collection_name,
-          authentication_note: s.authentication_note,
-          public_note: s.public_note,
-          note: s.note,
-          finding_aid: false
+          "library" => s.library,
+          "link" => s.link,
+          "link_text" => s.link_text,
+          "link_campus" => s.link_campus,
+          "interface_name" => s.interface_name,
+          "collection_name" => s.collection_name,
+          "authentication_note" => s.authentication_note,
+          "public_note" => s.public_note,
+          "note" => s.note,
+          "finding_aid" => false,
+          "status" => s.status
         }
       )
     end

--- a/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
@@ -71,22 +71,22 @@ describe Traject::UMich::ElectronicHolding do
       expect(subject.institution_codes).to eq(["MIFLIC"])
     end
   end
-  context "#link_campus" do
-    it "shows ann_arbor when no c code" do
-      expect(subject.link_campus).to eq("ann_arbor")
+  context "#campuses" do
+    it "shows both ann_arbor and flint when no c code" do
+      expect(subject.campuses).to contain_exactly("ann_arbor", "flint")
     end
-    it "shows ann_arbor when both UMAA and UMFL are present" do
+    it "shows both ann_arbor and flint when both UMAA and UMFL are present" do
       ann_arbor_campus
       flint_campus
-      expect(subject.link_campus).to eq("ann_arbor")
+      expect(subject.campuses).to contain_exactly("ann_arbor", "flint")
     end
     it "shows ann_arbor when c code is only UMAA" do
       ann_arbor_campus
-      expect(subject.link_campus).to eq("ann_arbor")
+      expect(subject.campuses).to contain_exactly("ann_arbor")
     end
     it "shows flint when c code is only UMFL" do
       flint_campus
-      expect(subject.link_campus).to eq("flint")
+      expect(subject.campuses).to contain_exactly("flint")
     end
   end
   context "#interface_name" do
@@ -137,7 +137,7 @@ describe Traject::UMich::ElectronicHolding do
           "library" => s.library,
           "link" => s.link,
           "link_text" => s.link_text,
-          "link_campus" => s.link_campus,
+          "campuses" => s.campuses,
           "interface_name" => s.interface_name,
           "collection_name" => s.collection_name,
           "authentication_note" => s.authentication_note,

--- a/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
@@ -1,0 +1,151 @@
+require "traject"
+require "umich_traject"
+describe Traject::UMich::ElectronicHolding do
+  def get_record(path)
+    MARC::XMLReader.new(path).first
+  end
+  let(:e_resource) do
+    get_record("./spec/fixtures/e_resource.xml")
+  end
+  let(:e56_1) do
+    e_resource.fields("E56").first
+  end
+  let(:e56_2) do
+    e_resource.fields("E56")[1]
+  end
+  let(:flint_campus) do
+    @e56.append(MARC::Subfield.new("c", "UMFL"))
+  end
+  let(:ann_arbor_campus) do
+    @e56.append(MARC::Subfield.new("c", "UMAA"))
+  end
+  before(:each) do
+    @e56 = e56_1
+  end
+  subject do
+    described_class.new(@e56)
+  end
+  context "#library" do
+    it "shows ELEC" do
+      expect(subject.library).to eq("ELEC")
+    end
+  end
+  context "#link_text" do
+    it "shows Available online" do
+      expect(subject.link_text).to eq("Available online")
+    end
+  end
+  context "#link" do
+    it "returns the link with the Ann Arbor view when there are no campuses" do
+      expect(subject.link).to include("openurl-UMAA")
+    end
+    it "returns the link with Ann Arbor view when both flint and ann arbor are campuses" do
+      ann_arbor_campus
+      flint_campus
+      expect(subject.link).to include("openurl-UMAA")
+    end
+    it "returns the link with Ann Arbor view when only Ann Arbor is listed" do
+      ann_arbor_campus
+      expect(subject.link).to include("openurl-UMAA")
+    end
+    it "returns the link with Flint view when only Flint is listed" do
+      flint_campus
+      expect(subject.link).to include("openurl-UMFL")
+    end
+  end
+  context "#institution_codes" do
+    it "shows both insitutions,for no c code" do
+      expect(subject.institution_codes).to eq(["MIU", "MIFLIC"])
+    end
+    it "shows both insitutions when both Flint and Ann Arbor are campuses " do
+      ann_arbor_campus
+      flint_campus
+      expect(subject.institution_codes).to eq(["MIU", "MIFLIC"])
+    end
+    it "shows only MIU when only Ann Arbor is a listed campus" do
+      ann_arbor_campus
+      expect(subject.institution_codes).to eq(["MIU"])
+    end
+    it "shows only MIFLIC when only Flint is a listed campus" do
+      flint_campus
+      expect(subject.institution_codes).to eq(["MIFLIC"])
+    end
+  end
+  context "#link_campus" do
+    it "shows ann_arbor when no c code" do
+      expect(subject.link_campus).to eq("ann_arbor")
+    end
+    it "shows ann_arbor when both UMAA and UMFL are present" do
+      ann_arbor_campus
+      flint_campus
+      expect(subject.link_campus).to eq("ann_arbor")
+    end
+    it "shows ann_arbor when c code is only UMAA" do
+      ann_arbor_campus
+      expect(subject.link_campus).to eq("ann_arbor")
+    end
+    it "shows flint when c code is only UMFL" do
+      flint_campus
+      expect(subject.link_campus).to eq("flint")
+    end
+  end
+  context "#interface_name" do
+    it "shows the interface from subfield m" do
+      expect(subject.interface_name).to eq("Elsevier ScienceDirect;")
+    end
+  end
+  context "#public_note" do
+    it "shows the public note from subfield z" do
+      expect(subject.public_note).to eq("Public note:")
+    end
+  end
+  context "#collection_name" do
+    it "show the collection_name from subfield n" do
+      expect(subject.collection_name).to eq("Elsevier SD eBook - Physics and Astronomy?")
+    end
+  end
+  context "#authentication_note" do
+    it "shows the authentication note from subfield 4" do
+      expect(subject.authentication_note).to eq(["Access to the Elsevier ScienceDirect eBook - Physics and Astronomy (Legacy 1) online version restricted; authentication may be required.", "Elsevier ScienceDirect access restricted; authentication may be required."])
+    end
+  end
+  context "#note" do
+    it "shows combined note" do
+      expect(subject.note).to eq("Elsevier ScienceDirect. Elsevier SD eBook - Physics and Astronomy. Access to the Elsevier ScienceDirect eBook - Physics and Astronomy (Legacy 1) online version restricted; authentication may be required. Elsevier ScienceDirect access restricted; authentication may be required. Public note.")
+    end
+  end
+  context "#status" do
+    it "shows the status in subfield s" do
+      expect(subject.status).to eq("Available")
+    end
+  end
+  context "#description" do
+    it "shows the description in subfield 3" do
+      expect(subject.description).to eq("Description")
+    end
+  end
+  context "#finding_aid" do
+    it "is false" do
+      expect(subject.finding_aid).to eq(false)
+    end
+  end
+  context "#to_h" do
+    it "returns expected hash" do
+      s = subject
+      expect(s.to_h).to eq(
+        {
+          library: s.library,
+          link: s.link,
+          link_text: s.link_text,
+          institution_codes: s.institution_codes,
+          interface_name: s.interface_name,
+          collection_name: s.collection_name,
+          authentication_note: s.authentication_note,
+          public_note: s.public_note,
+          note: s.note,
+          finding_aid: false
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR Handles [LIBSEARCH-923](https://mlit.atlassian.net/browse/LIBSEARCH-923) and  [LIBSEARCH-925](https://mlit.atlassian.net/browse/LIBSEARCH-925).

It refactors the logic for handling e56 fields, adds in tests, and then adds the changes for handling these fields. 

It exposes the campuses related to e56 holdings in the `hol` json structure.