### PR TITLE
adds description back into electronic holding output

### DIFF
--- a/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
@@ -91,6 +91,7 @@ module Traject
           "interface_name",
           "collection_name",
           "authentication_note",
+          "description",
           "public_note",
           "note",
           "finding_aid",

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -29,6 +29,7 @@ describe "umich_alma" do
         "interface_name" => "archived issues via the International Society of Arboriculture",
         "public_note" => "Access to archived issues via the International Society of Arboriculture online version:",
         "note" => "archived issues via the International Society of Arboriculture. Access to archived issues via the International Society of Arboriculture online version.",
+        "description" => nil,
         "status" => "Available",
 
         "finding_aid" => false,
@@ -43,6 +44,7 @@ describe "umich_alma" do
         "https://na04.alma.exlibrisgroup.com/view/uresolver/01UMICH_INST/openurl-UMAA?u.ignore_date_coverage=true&portfolio_pid=531031051590006381&Force_direct=true",
         "link_text" => "Available online",
         "campuses" => ["ann_arbor", "flint"],
+        "description" => nil,
         "public_note" =>
         "Institutional password required for access to the International Society of Arboriculture online version; authentication required:",
         "note" =>

--- a/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
@@ -138,6 +138,7 @@ describe Traject::UMich::ElectronicHolding do
           "link" => s.link,
           "link_text" => s.link_text,
           "campuses" => s.campuses,
+          "description" => s.description,
           "interface_name" => s.interface_name,
           "collection_name" => s.collection_name,
           "authentication_note" => s.authentication_note,


### PR DESCRIPTION
Forgot to add description to the holding structure output for e56s. This puts it back.