### PR TITLE
Fix Ampersand problem in HT source

### DIFF
--- a/umich_catalog_indexing/indexers/umich_alma.rb
+++ b/umich_catalog_indexing/indexers/umich_alma.rb
@@ -11,6 +11,7 @@ else
   require "ht_traject/ht_hathifiles"
   HathiTrust::HathiFiles
 end
+S.logger.info(HathiFiles)
 
 libLocInfo = Traject::TranslationMap.new("umich/libLocInfo")
 electronic_collections = Traject::TranslationMap.new("umich/electronic_collections")
@@ -70,7 +71,7 @@ each_record do |r, context|
       item[:rights] = f["r"]
       item[:description] = f["z"]
       item[:collection_code] = f["c"]
-      item[:source] = cc_to_of[f["c"].downcase]
+      item[:source] = CGI.unescapeHTML(cc_to_of[f["c"].downcase])
       item[:access] = !!(item[:rights] =~ /^(pd|world|ic-world|cc|und-world)/)
       # item[:status] = statusFromRights(item[:rights], etas_status)
       item[:status] = statusFromRights(item[:rights])

--- a/umich_catalog_indexing/lib/ht_traject/ht_hathifiles.rb
+++ b/umich_catalog_indexing/lib/ht_traject/ht_hathifiles.rb
@@ -47,7 +47,7 @@ module HathiTrust
 
       query(bib_nums: bib_nums, oclc_nums: oclc_nums).each do |r|
         hf_hash[r[:id]] = r
-        hf_hash[r[:id]]["source"] = CC_TO_OF[r[:collection_code].downcase]
+        hf_hash[r[:id]]["source"] = CGI.unescapeHTML(CC_TO_OF[r[:collection_code].downcase])
       end
 
       hf_hash.values


### PR DESCRIPTION
The collection_code translation map has HTML codes for "&". This PR adds an unescape step before writing it to the solr document.