### PR TITLE
Libsearch 955 availability filters

### DIFF
--- a/biblio/conf/schema/local_explicit_fields.xml
+++ b/biblio/conf/schema/local_explicit_fields.xml
@@ -106,6 +106,7 @@
 <field name="language008_full" type="string" indexed="true" stored="true"  multiValued="false"/>
 <field name="format"       type="string"     indexed="true" stored="true"  multiValued="true"/>
 <field name="availability" type="string"     indexed="true" stored="true"  multiValued="true"/>
+<field name="new_availability" type="string"     indexed="true" stored="true"  multiValued="true"/>
 <field name="publisher"    type="text_no_stem_or_synonyms" indexed="true" stored="true" multiValued="true"/>
 <field name="publisher_display"    type="text_no_stem_or_synonyms" indexed="true" stored="true" multiValued="true"/>
 <field name="edition"      type="string"     indexed="true" stored="true" multiValued="true"/>

--- a/umich_catalog_indexing/indexers/umich.rb
+++ b/umich_catalog_indexing/indexers/umich.rb
@@ -94,6 +94,8 @@ each_record do |rec, context|
   context.clipboard[:ht][:has_non_ht_holding] = has_non_ht_holding
 end
 
+# Is true when the item is a zephir record that does not have any full text items.
+# This should be removable when filtering out zephir search only happens. Then this can be set to false always.
 to_field "ht_searchonly" do |record, acc, context|
   has_ht_fulltext = context.clipboard[:ht][:items]&.us_fulltext? || false
   acc << if has_ht_fulltext or context.clipboard[:ht][:has_non_ht_holding] or context.clipboard[:ht][:record_source] == "alma"
@@ -103,6 +105,7 @@ to_field "ht_searchonly" do |record, acc, context|
   end
 end
 
+# Do we even use intl anywhere?
 to_field "ht_searchonly_intl" do |record, acc, context|
   has_ht_fulltext = context.clipboard[:ht][:items]&.intl_fulltext? || false
   acc << if has_ht_fulltext or context.clipboard[:ht][:has_non_ht_holding]
@@ -113,5 +116,5 @@ to_field "ht_searchonly_intl" do |record, acc, context|
 end
 
 #### Availability ####
-#
+# mrio: Pretty sure this is dead code
 to_field "availability", extract_marc("973b", translation_map: "umich/availability_map_umich")

--- a/umich_catalog_indexing/indexers/umich.rb
+++ b/umich_catalog_indexing/indexers/umich.rb
@@ -1,71 +1,65 @@
-require 'umich_traject'
+require "umich_traject"
 
-
-###Date the record was added to the catalog####
+# ##Date the record was added to the catalog####
 # cat_date -- first few digits of the 006 field
 # the acc.replace line is there because sometimes there are multiple
-# 008 fields and that messes stuff up. example: 99187608751706381 
+# 008 fields and that messes stuff up. example: 99187608751706381
 # from 2022-10-14
 
-to_field 'cat_date', extract_marc('008[00-05]') do |rec, acc, context|
-  acc.map! do |str| 
-    begin
-      Date.parse(str).strftime("%Y%m%d") 
-    rescue
-      '00000000'
-    end 
+to_field "cat_date", extract_marc("008[00-05]") do |rec, acc, context|
+  acc.map! do |str|
+    Date.parse(str).strftime("%Y%m%d")
+  rescue
+    "00000000"
   end
   acc.replace [acc.max]
 end
 
-
 #### Fund that was used to pay for it ####
 
-to_field 'fund', extract_marc('949a')
-to_field 'fund_display' do |rec, acc|
-  acc.concat Traject::MarcExtractor.cached('949ad', :separator => ' - ').extract(rec)
+to_field "fund", extract_marc("949a")
+to_field "fund_display" do |rec, acc|
+  acc.concat Traject::MarcExtractor.cached("949ad", separator: " - ").extract(rec)
 end
-to_field 'bookplate', extract_marc('949a', :translation_map => "umich/bookplates")
+to_field "bookplate", extract_marc("949a", translation_map: "umich/bookplates")
 
 ### mrio: updated Feb 2022
-to_field 'preferred_citation', extract_marc('524a')
-to_field 'location_of_originals', extract_marc('535')
-to_field 'funding_information', extract_marc('536a')
-to_field 'source_of_acquisition', extract_marc('541a')
-to_field 'map_scale', extract_marc('255a')
+to_field "preferred_citation", extract_marc("524a")
+to_field "location_of_originals", extract_marc("535")
+to_field "funding_information", extract_marc("536a")
+to_field "source_of_acquisition", extract_marc("541a")
+to_field "map_scale", extract_marc("255a")
 
-###---end Feb 2022 update###
+# ##---end Feb 2022 update###
 #
-to_field 'content_advice'  do |rec, acc|
-  advice = rec.fields("520").select{|x| x.indicator1 == "4"}.map{|x| x.value}
+to_field "content_advice" do |rec, acc|
+  advice = rec.fields("520").select { |x| x.indicator1 == "4" }.map { |x| x.value }
   acc.replace advice
 end
 
-
 ##### Location ####
 
-#to_field 'institution', extract_marc('971a', :translation_map => 'umich/institution_map')
-#MIU, MIU-C, MIU-H, MIFLIC
-#inst_map = Traject::TranslationMap.new('umich/institution_map')
-#to_field 'institution', extract_marc('958a') do |rec, acc, context|
+# to_field 'institution', extract_marc('971a', :translation_map => 'umich/institution_map')
+# MIU, MIU-C, MIU-H, MIFLIC
+# inst_map = Traject::TranslationMap.new('umich/institution_map')
+# to_field 'institution', extract_marc('958a') do |rec, acc, context|
 #  acc << 'MiU' if context.clipboard[:ht][:record_source] == 'zephir'   # add MiU as an institution for zephir records
 #  acc.map! { |code| inst_map[code.strip] }
 #  acc.flatten!
 #  acc.uniq!
-#end
+# end
 
 building_map = Traject::UMich.building_map
-to_field 'building', extract_marc('852bc:971a') do |rec, acc|
+to_field "building", extract_marc("852bc:971a") do |rec, acc|
   acc.map! { |code| building_map[code.strip] }
   acc.flatten!
   acc.uniq!
 end
 
-
 # Apply Best Bets
-require 'best_bets'
+require "best_bets"
 
-BestBets.load('https://apps.lib.umich.edu/admin/bestbets/export').each_term do |term|
+BestBets.load("https://apps.lib.umich.edu/admin/bestbets/export").each_term do |term|
   to_field(term.to_field) do |rec, acc|
     term.on(rec[term.marc].value) do |rank|
       acc << rank
@@ -73,56 +67,51 @@ BestBets.load('https://apps.lib.umich.edu/admin/bestbets/export').each_term do |
   end
 end
 
-
 # UMich-specific stuff based on Hathitrust. For Mirlyn, we say something is
 # htso iff it has no ht fulltext, and no other holdings. Basically, this is
 # the "can I somehow get to the full text of this without resorting to
 # ILL" field in Mirlyn
 
-
 # An item in Mirlyn is search only if
 #  - there's no HT fulltext
 #  - there's no other physical or electronic holdings
 
-
 # First we'll figure out whether we have holdings
-F973b = Traject::MarcExtractor.cached('973b')
-F852b = Traject::MarcExtractor.cached('852b')
+F973b = Traject::MarcExtractor.cached("973b")
+F852b = Traject::MarcExtractor.cached("852b")
 
 each_record do |rec, context|
   has_non_ht_holding = false
 
   F973b.extract(rec).each do |val|
-    has_non_ht_holding = true if ['avail_online', 'avail_circ'].include? val
+    has_non_ht_holding = true if ["avail_online", "avail_circ"].include? val
   end
 
   F852b.extract(rec).each do |val|
-    has_non_ht_holding = true unless val == 'SDR'
+    has_non_ht_holding = true unless val == "SDR"
   end
 
   context.clipboard[:ht][:has_non_ht_holding] = has_non_ht_holding
 end
 
-
-to_field 'ht_searchonly' do |record, acc, context|
+to_field "ht_searchonly" do |record, acc, context|
   has_ht_fulltext = context.clipboard[:ht][:items]&.us_fulltext? || false
-  if has_ht_fulltext or context.clipboard[:ht][:has_non_ht_holding] or context.clipboard[:ht][:record_source] == 'alma'
-    acc << false
+  acc << if has_ht_fulltext or context.clipboard[:ht][:has_non_ht_holding] or context.clipboard[:ht][:record_source] == "alma"
+    false
   else
-    acc << true
+    true
   end
 end
 
-to_field 'ht_searchonly_intl' do |record, acc, context|
+to_field "ht_searchonly_intl" do |record, acc, context|
   has_ht_fulltext = context.clipboard[:ht][:items]&.intl_fulltext? || false
-  if has_ht_fulltext or context.clipboard[:ht][:has_non_ht_holding]
-    acc << false
+  acc << if has_ht_fulltext or context.clipboard[:ht][:has_non_ht_holding]
+    false
   else
-    acc << true
+    true
   end
 end
-
 
 #### Availability ####
 #
-to_field 'availability', extract_marc('973b', :translation_map => 'umich/availability_map_umich')
+to_field "availability", extract_marc("973b", translation_map: "umich/availability_map_umich")

--- a/umich_catalog_indexing/indexers/umich_alma.rb
+++ b/umich_catalog_indexing/indexers/umich_alma.rb
@@ -146,6 +146,10 @@ to_field "availability" do |record, acc, context|
   acc.replace Array(context.clipboard[:ht][:availability].map { |code| avail_map[code] })
 end
 
+to_field "new_availability" do |record, acc, context|
+  acc << Traject::UMich::Availability.new(context.clipboard[:ht][:hol_list]).to_a
+end
+
 location_map = Traject::UMich.location_map
 to_field "location" do |record, acc, context|
   locations = Array(context.clipboard[:ht][:locations])

--- a/umich_catalog_indexing/lib/umich_traject.rb
+++ b/umich_catalog_indexing/lib/umich_traject.rb
@@ -9,5 +9,6 @@ require "umich_traject/digital_holding"
 require "umich_traject/physical_holding"
 require "umich_traject/physical_item"
 require "umich_traject/electronic_holding"
+require "umich_traject/availability"
 
 UMich::FloorLocation.configure("lib/translation_maps/umich/floor_locations.json")

--- a/umich_catalog_indexing/lib/umich_traject/availability.rb
+++ b/umich_catalog_indexing/lib/umich_traject/availability.rb
@@ -39,6 +39,14 @@ module Traject
         @hol.select { |x| ALMA_ELECTRONIC_LIBRARIES.any?(x["library"]) }.any?
       end
 
+      def hathi_trust_or_electronic_holding?
+        hathi_trust? || electronic_holding?
+      end
+
+      def hathi_trust_full_text_or_electronic_holding?
+        hathi_trust_full_text? || electronic_holding?
+      end
+
       # Returns an array of availabilies for the holding structure. This is the
       # method that's called by the application.
       # @return [Array<String>]
@@ -47,7 +55,8 @@ module Traject
           "physical",
           "hathi_trust",
           "hathi_trust_full_text",
-          "electronic_holding"
+          "hathi_trust_or_electronic_holding",
+          "hathi_trust_full_text_or_electronic_holding"
         ].select { |x| send(:"#{x}?") }
       end
 

--- a/umich_catalog_indexing/lib/umich_traject/availability.rb
+++ b/umich_catalog_indexing/lib/umich_traject/availability.rb
@@ -1,0 +1,63 @@
+module Traject
+  module UMich
+    class Availability
+      ELECTRONIC_LIBRARIES = ["HathiTrust Digital Library", "ELEC", "ALMA_DIGITAL"]
+      ALMA_ELECTRONIC_LIBRARIES = ["ELEC", "ALMA_DIGITAL"]
+
+      # @param hol [Array<Hash>] holding structure
+      def initialize(hol)
+        @hol = hol
+      end
+
+      # Record has at least one physical item
+      # @return [Boolean]
+      def physical?
+        @hol.reject { |x| ELECTRONIC_LIBRARIES.any?(x["library"]) }.any?
+      end
+
+      # Record has at least one Hathi Trust item
+      # @return [Boolean]
+      def hathi_trust?
+        @hol.any? { |x| x["library"] == "HathiTrust Digital Library" }
+      end
+
+      # Record has at least one Hathi Trust Full Text item
+      # @return [Boolean]
+      def hathi_trust_full_text?
+        @hol.select do |holding|
+          holding["library"] == "HathiTrust Digital Library"
+        end.any? do |ht_holding|
+          ht_holding["items"].any? do |item|
+            _full_text_from_rights?(item["rights"])
+          end
+        end
+      end
+
+      # Record has at least one record from an electronic library
+      # @return [Boolean]
+      def electronic_holding?
+        @hol.select { |x| ALMA_ELECTRONIC_LIBRARIES.any?(x["library"]) }.any?
+      end
+
+      # Returns an array of availabilies for the holding structure. This is the
+      # method that's called by the application.
+      # @return [Array<String>]
+      def to_a
+        [
+          "physical",
+          "hathi_trust",
+          "hathi_trust_full_text",
+          "electronic_holding"
+        ].select { |x| send(:"#{x}?") }
+      end
+
+      # Does the rights code indicate that that item is availble for full text
+      # viewing?
+      # https://github.com/hathitrust/hathifiles/blob/main/lib/item_record.rb#L24
+      # @return [Boolean]
+      def _full_text_from_rights?(rights)
+        /^(pdus$|pd$|world|cc|und-world|ic-world)/.match?(rights)
+      end
+    end
+  end
+end

--- a/umich_catalog_indexing/lib/umich_traject/holdings.rb
+++ b/umich_catalog_indexing/lib/umich_traject/holdings.rb
@@ -184,7 +184,8 @@ module Traject
       end
 
       def statusFromRights(rights, etas = false)
-        if /^(pd|world|cc|und-world|ic-world)/.match?(rights)
+        # from https://github.com/hathitrust/hathifiles/blob/main/lib/item_record.rb#L24
+        if /^(pdus$|pd$|world|cc|und-world|ic-world)/.match?(rights)
           "Full text"
         elsif etas
           "Full text available, simultaneous access is limited (HathiTrust log in required)"

--- a/umich_catalog_indexing/spec/fixtures/hol.json
+++ b/umich_catalog_indexing/spec/fixtures/hol.json
@@ -1,0 +1,52 @@
+[
+  {
+    "hol_mmsid": "22975380140006381",
+    "callnumber": "M 3 .P52 1993",
+    "library": "MUSIC",
+    "location": "NONE",
+    "info_link": "http://lib.umich.edu/locations-and-hours/music-library",
+    "display_name": "Music",
+    "floor_location": "",
+    "public_note": null,
+    "items": [
+      {
+        "barcode": "39015040218748",
+        "library": "MUSIC",
+        "location": "NONE",
+        "info_link": "http://lib.umich.edu/locations-and-hours/music-library",
+        "display_name": "Music",
+        "fulfillment_unit": "General",
+        "location_type": "OPEN",
+        "can_reserve": false,
+        "permanent_library": "MUSIC",
+        "permanent_location": "NONE",
+        "temp_location": false,
+        "callnumber": "M 3 .P52 1993",
+        "public_note": null,
+        "process_type": null,
+        "item_policy": "08",
+        "description": null,
+        "inventory_number": null,
+        "item_id": "23975380130006381",
+        "material_type": "SCORE",
+        "record_has_finding_aid": false
+      }
+    ],
+    "summary_holdings": null,
+    "record_has_finding_aid": false
+  },
+  {
+    "library": "HathiTrust Digital Library",
+    "items": [
+      {
+        "id": "mdp.39015040218748",
+        "rights": "ic",
+        "description": "",
+        "collection_code": "MIU",
+        "access": false,
+        "source": "University of Michigan",
+        "status": "Search only (no full text)"
+      }
+    ]
+  }
+]

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -155,6 +155,16 @@ describe "umich_alma" do
   subject do
     indexer.process_record(@record).output_hash
   end
+  context "availability" do
+    it "has expected availability for Physical Item" do
+      @record = hurdy_gurdy
+      expect(subject["availability"]).to contain_exactly("Circulating Items")
+    end
+    it "has expected availability for Electronic Item" do
+      @record = arborist
+      expect(subject["availability"]).to contain_exactly("Circulating Items", "Available online")
+    end
+  end
   it "has expected physical hol" do
     @record = hurdy_gurdy
     # item_policy = @record["974"].subfields.find{|s| s.code == "p" }

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -12,9 +12,14 @@ describe "umich_alma" do
   let(:arborist) do
     get_record("./spec/fixtures/arborist.xml")
   end
+  let(:zephir_record) do
+    file = JSON.parse(fixture("zephir_record.json"))
+    MARC::Record.new_from_hash(file)
+  end
   let(:indexer) do
     Traject::Indexer.new do
       load_config_file("./spec/support/traject_settings.rb")
+      load_config_file("./indexers/common.rb")
       load_config_file("./indexers/umich_alma.rb")
     end
   end
@@ -163,6 +168,10 @@ describe "umich_alma" do
     it "has expected availability for Electronic Item" do
       @record = arborist
       expect(subject["availability"]).to contain_exactly("Circulating Items", "Available online")
+    end
+    it "has expected availability for Hathi Record" do
+      @record = zephir_record
+      expect(subject["availability"]).to contain_exactly("HathiTrust")
     end
   end
   it "has expected physical hol" do

--- a/umich_catalog_indexing/spec/traject/umich/availability_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/availability_spec.rb
@@ -53,10 +53,38 @@ describe Traject::UMich::Availability do
     end
   end
 
+  context "hathi_trust_or_electronic_holding?" do
+    it "returns true when hathitrust item" do
+      expect(subject.hathi_trust_or_electronic_holding?).to eq(true)
+    end
+    it "returns true when there's an electronic holding" do
+      @hol[1]["library"] = "ELEC"
+      expect(subject.hathi_trust_or_electronic_holding?).to eq(true)
+    end
+    it "returns false when there's no electronic or HT record" do
+      @hol.delete_at(1)
+      expect(subject.hathi_trust_or_electronic_holding?).to eq(false)
+    end
+  end
+
+  context "hathi_trust_full_text_or_electronic_holding?" do
+    it "returns false when neither ht full text or electronic holding" do
+      expect(subject.hathi_trust_full_text_or_electronic_holding?).to eq(false)
+    end
+    it "returns true when hathitrust full text" do
+      @hol[1]["items"].push({"rights" => "pd"})
+      expect(subject.hathi_trust_full_text_or_electronic_holding?).to eq(true)
+    end
+    it "returns true when there's an electronic holding" do
+      @hol[1]["library"] = "ELEC"
+      expect(subject.hathi_trust_full_text_or_electronic_holding?).to eq(true)
+    end
+  end
+
   context "#to_a" do
     it "returns an array of availability values" do
       expect(subject.to_a).to contain_exactly(
-        "physical", "hathi_trust"
+        "physical", "hathi_trust", "hathi_trust_or_electronic_holding"
       )
     end
   end

--- a/umich_catalog_indexing/spec/traject/umich/availability_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/availability_spec.rb
@@ -1,0 +1,63 @@
+require "traject"
+require "umich_traject"
+describe Traject::UMich::Availability do
+  before(:each) do
+    @hol = JSON.parse(fixture("/hol.json"))
+  end
+  subject do
+    described_class.new(@hol)
+  end
+  context "#physical?" do
+    it "is true when there is at least one physical item" do
+      expect(subject.physical?).to eq(true)
+    end
+    it "is false when there are no physical items" do
+      @hol.delete_at(0)
+      expect(subject.physical?).to eq(false)
+    end
+  end
+  context "#hathi_trust?" do
+    it "is true when there is at least one HathiTrust item" do
+      expect(subject.hathi_trust?).to eq(true)
+    end
+    it "is false when there are no HathiTrust items" do
+      @hol.delete_at(1)
+      expect(subject.hathi_trust?).to eq(false)
+    end
+  end
+  context "#hathi_trust_full_text?" do
+    it "is true when there is at least one HathiTrust item that is full text" do
+      @hol[1]["items"].push({"rights" => "pd"})
+      expect(subject.hathi_trust_full_text?).to eq(true)
+    end
+    it "is false when there are no public domain items" do
+      expect(subject.hathi_trust_full_text?).to eq(false)
+    end
+    it "is false when there are no HathiTrust items" do
+      @hol.delete_at(1)
+      expect(subject.hathi_trust_full_text?).to eq(false)
+    end
+  end
+
+  context "#electronic_holding?" do
+    it "is true when there is an alma electronic record" do
+      @hol[1]["library"] = "ELEC"
+      expect(subject.electronic_holding?).to eq(true)
+    end
+    it "is true when there is an alma digital record" do
+      @hol[1]["library"] = "ALMA_DIGITAL"
+      expect(subject.electronic_holding?).to eq(true)
+    end
+    it "is false when there is only HathiTrust" do
+      expect(subject.electronic_holding?).to eq(false)
+    end
+  end
+
+  context "#to_a" do
+    it "returns an array of availability values" do
+      expect(subject.to_a).to contain_exactly(
+        "physical", "hathi_trust"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Adds the field `new_availability` to the solr config. 5 states are added to this field:

* `physical`
* `hathi_trust`
* `hathi_trust_full_text`
* `hathi_trust_or_electronic_holding`
* `hathi_trust_full_text_or_electronic_holding`

These five fields account for whether or not a user wants to included HathiTrust Search only materials in their results.