### PR TITLE
Availability filters

### DIFF
--- a/umich_catalog_indexing/indexers/umich_alma.rb
+++ b/umich_catalog_indexing/indexers/umich_alma.rb
@@ -147,7 +147,7 @@ to_field "availability" do |record, acc, context|
 end
 
 to_field "new_availability" do |record, acc, context|
-  acc << Traject::UMich::Availability.new(context.clipboard[:ht][:hol_list]).to_a
+  acc.replace Traject::UMich::Availability.new(context.clipboard[:ht][:hol_list]).to_a
 end
 
 location_map = Traject::UMich.location_map

--- a/umich_catalog_indexing/lib/umich_traject/availability.rb
+++ b/umich_catalog_indexing/lib/umich_traject/availability.rb
@@ -6,7 +6,7 @@ module Traject
 
       # @param hol [Array<Hash>] holding structure
       def initialize(hol)
-        @hol = hol
+        @hol = JSON.parse(hol.to_json)
       end
 
       # Record has at least one physical item


### PR DESCRIPTION
Fix to availability filters so that it works as hoped. 

Zephir holdings have keys with symbols, and alma holdings have keys with strings, so the availability class changes all of the keys to strings before passing the holding on to the methods. 

The new_availability field replaces the `acc` instead of appending to it. 