### PR TITLE
Remove 4 from main_author_display

### DIFF
--- a/umich_catalog_indexing/indexers/common.rb
+++ b/umich_catalog_indexing/indexers/common.rb
@@ -186,8 +186,7 @@ to_field "author_browse_terms" do |rec, acc, _context|
   acc.replace authors.flatten.compact
 end
 
-# changes by mrio Feb 2022
-to_field "main_author_display", extract_marc("100abcdefgjklnpqtu4:101abcdefgjklnpqtu4:110abcdefgjklnpqtu4:111abcdefgjklnpqtu4")
+to_field "main_author_display", extract_marc("100abcdefgjklnpqtu:101abcdefgjklnpqtu:110abcdefgjklnpqtu:111abcdefgjklnpqtu")
 to_field "main_author", extract_marc("100abcdgjkqu:101abcdgjkqu:110abcdgjkqu:111abcdgjkqu")
 
 # TODO: Change traject to allow, e.g., 700|*[^ ]abc where brackets indicate a regex


### PR DESCRIPTION
Including the 4 field caused the Carousel to have wrapping problems, and we realized that it doesn't make sense to include the 4 subfield in the display anyway.

https://mlit.atlassian.net/browse/LIBSEARCH-977