### PR TITLE
Hotfix: Add PURD to colllection code translation map

### DIFF
--- a/umich_catalog_indexing/lib/translation_maps/ht/collection_code_to_original_from.yaml
+++ b/umich_catalog_indexing/lib/translation_maps/ht/collection_code_to_original_from.yaml
@@ -60,6 +60,7 @@ ppt: Temple University
 pst: Pennsylvania State University
 pu: University of Pennsylvania
 pur: Purdue University
+purd: Purdue University
 qmm: McGill University
 scu: University of South Carolina
 srlf: University of California


### PR DESCRIPTION
The lack of `purd` in the collection code to original form translation map broke indexing. This should fix it.