### PR TITLE
LIBSEARCH-942 adds 752 to subject field

### DIFF
--- a/umich_catalog_indexing/lib/common/subjects.rb
+++ b/umich_catalog_indexing/lib/common/subjects.rb
@@ -30,7 +30,8 @@ module Common
       "657" => "avxyz",
       "658" => "ab",
       "662" => "abcdefgh",
-      "690" => "abcdevxyz"
+      "690" => "abcdevxyz",
+      "752" => "abcdefgh"
     }
     SUBJECT_FIELDS = TOPICS.keys
     REMEDIATION_MAP = RemediationMap.new

--- a/umich_catalog_indexing/lib/common/subjects.rb
+++ b/umich_catalog_indexing/lib/common/subjects.rb
@@ -57,7 +57,7 @@ module Common
 
     # @return [Array<String>] An array of all subject browse strings
     def subject_browse_subjects
-      _subject_strings(subject_browse_subject_fields, "--")
+      _subject_strings(subject_browse_subject_fields, false)
     end
 
     # The delimiter needed for Library Search is " -- " because of line
@@ -65,9 +65,9 @@ module Common
     # spaces
     #
     # @return[Array<String>] Ann array of subject strings
-    def _subject_strings(fields, delimiter = " -- ")
+    def _subject_strings(fields, padding = true)
       fields.map do |f|
-        Subject.new(f).subject_string(delimiter)
+        Subject.new(f).subject_string(padding: padding)
       end
     end
 

--- a/umich_catalog_indexing/lib/common/subjects/lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subjects/lc_subject.rb
@@ -63,7 +63,8 @@ module Common
       # Most subject fields are constructed by joining together the alphabetic subfields
       # with either a '--' (before a $v, $x, $y, or $z) or a space (before everything else).
       # @return [String] An appropriately-delimited string
-      def subject_string(delimiter = default_delimiter)
+      def subject_string(padding: false)
+        delimiter = _delimiter_string(padding)
         str = subject_data_subfield_codes.map do |sf|
           case sf.code
           when *DELIMITED_FIELDS
@@ -75,12 +76,17 @@ module Common
 
         normalize(str)
       end
+
+      def _delimiter_string(padding)
+        padding ? " #{default_delimiter} " : default_delimiter
+      end
     end
 
     class LCSubject658 < LCSubject
       # Format taken from the MARC 658 documentation
       # @return [String] Subject string ready for output
-      def subject_string(delimiter = default_delimiter)
+      def subject_string(padding: false)
+        delimiter = _delimiter_string(padding)
         str = subject_data_subfield_codes.map do |sf|
           case sf.code
           when "b"
@@ -105,7 +111,8 @@ module Common
       # At least one subject field in LC, the 662, just gets delimiters everywhere
       # Format taken from the MARC 662 documentation
       # @return [String] Subject string ready for output
-      def subject_string(delimiter = default_delimiter)
+      def subject_string(padding: false)
+        delimiter = _delimiter_string(padding)
         normalize(subject_data_subfield_codes.map(&:value).join(delimiter))
       end
     end

--- a/umich_catalog_indexing/lib/common/subjects/lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subjects/lc_subject.rb
@@ -15,7 +15,9 @@ module Common
         when "658"
           LCSubject658.new(field)
         when "662"
-          LCSubjectHierarchical(field)
+          LCSubjectHierarchical.new(field)
+        when "752"
+          LCAddedEntryHeirarchical.new(field)
         else
           new(field)
         end
@@ -58,7 +60,9 @@ module Common
       end
 
       # Only some fields get delimiters before them in a standard LC Subject field
-      DELIMITED_FIELDS = %w[v x y z]
+      def delimited_fields
+        %w[v x y z]
+      end
 
       # Most subject fields are constructed by joining together the alphabetic subfields
       # with either a '--' (before a $v, $x, $y, or $z) or a space (before everything else).
@@ -67,7 +71,7 @@ module Common
         delimiter = _delimiter_string(padding)
         str = subject_data_subfield_codes.map do |sf|
           case sf.code
-          when *DELIMITED_FIELDS
+          when *delimited_fields
             "#{delimiter}#{sf.value}"
           else
             " #{sf.value}"
@@ -114,6 +118,17 @@ module Common
       def subject_string(padding: false)
         delimiter = _delimiter_string(padding)
         normalize(subject_data_subfield_codes.map(&:value).join(delimiter))
+      end
+    end
+
+    # Taken from https://www.loc.gov/marc/bibliographic/bd752.html
+    class LCAddedEntryHeirarchical < LCSubject
+      def delimited_fields
+        %w[a b c d e f g h]
+      end
+
+      def default_delimiter
+        "-"
       end
     end
   end

--- a/umich_catalog_indexing/lib/common/subjects/non_lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subjects/non_lc_subject.rb
@@ -4,11 +4,27 @@ require_relative "lc_subject"
 
 module Common
   class Subjects
-    # According to the LC docs, non-LC subjects follow the same formatting and data
-    # standards as LC, so this needs not do anything special until we learn otherwise.
+    # According to the LC docs, non-LC subjects follow the same formatting and
+    # data standards as LC, so this needs not do anything special until we
+    # learn otherwise.
     class NonLCSubject < Common::Subjects::LCSubject
+      def self.from_field(field)
+        case field.tag
+        when "752"
+          NonLCAddedEntryHeirarchical.new(field)
+        else
+          new(field)
+        end
+      end
+
       # Here for testing purposes to distinguish from the LC subjects
       # @return [Boolean]
+      def lc_subject_field?
+        false
+      end
+    end
+
+    class NonLCAddedEntryHeirarchical < Common::Subjects::LCAddedEntryHeirarchical
       def lc_subject_field?
         false
       end

--- a/umich_catalog_indexing/lib/common/subjects/subject.rb
+++ b/umich_catalog_indexing/lib/common/subjects/subject.rb
@@ -16,7 +16,7 @@ module Common
           if lc_subject_field?(field)
             LCSubject.from_field(field)
           else
-            NonLCSubject.new(field)
+            NonLCSubject.from_field(field)
           end
         end
       end

--- a/umich_catalog_indexing/spec/common/subject/lc_subject_spec.rb
+++ b/umich_catalog_indexing/spec/common/subject/lc_subject_spec.rb
@@ -83,3 +83,23 @@ RSpec.describe Common::Subjects::LCSubjectHierarchical do
     end
   end
 end
+RSpec.describe Common::Subjects::LCAddedEntryHeirarchical do
+  let(:subject_field) do
+    MARC::DataField.new("752", "", "",
+      ["a", "World"],
+      ["b", "Asia"],
+      ["c", "Japan"],
+      ["d", "Hokkaido (island)"],
+      ["e", "Hokkaido (region)"],
+      ["f", "Hokkaido (prefecture)"],
+      ["g", "Asahi-Dake"],
+      ["h", "Something Else."],
+      ["2", "tgn"])
+  end
+  context "#subject_string" do
+    it "returns expected output" do
+      output = described_class.new(subject_field).subject_string
+      expect(output).to eq("World-Asia-Japan-Hokkaido (island)-Hokkaido (region)-Hokkaido (prefecture)-Asahi-Dake-Something Else")
+    end
+  end
+end


### PR DESCRIPTION
Addresses [LIBSEARCH-942](https://mlit.atlassian.net/browse/LIBSEARCH-942)

Changes call for a delimiter in subjects to be a call for adding padding. 
Adds 752 as a subject field and follows the [display rules](https://www.loc.gov/marc/bibliographic/bd752.html).