### PR TITLE
Libsearch 944 language codes in 041

### DIFF
--- a/umich_catalog_indexing/spec/common/subject/subject_spec.rb
+++ b/umich_catalog_indexing/spec/common/subject/subject_spec.rb
@@ -1,8 +1,5 @@
 require "common/subjects"
 RSpec.describe Common::Subjects::Subject do
-  def get_record(path)
-    MARC::XMLReader.new(path).first
-  end
   let(:record) do
     get_record("./spec/fixtures/unauthorized_immigrants.xml")
   end

--- a/umich_catalog_indexing/spec/common/subjects_spec.rb
+++ b/umich_catalog_indexing/spec/common/subjects_spec.rb
@@ -1,9 +1,6 @@
 require "common/subjects"
 require "marc"
 RSpec.describe Common::Subjects do
-  def get_record(path)
-    MARC::XMLReader.new(path).first
-  end
   let(:record) do
     get_record("./spec/fixtures/unauthorized_immigrants.xml")
   end

--- a/umich_catalog_indexing/spec/fixtures/grudencz.xml
+++ b/umich_catalog_indexing/spec/fixtures/grudencz.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection>
+	<record>
+		<leader>     ncm a22003131a 4500</leader>
+		<controlfield tag="005">20040421000000.0</controlfield>
+		<controlfield tag="008">990802s1993    pl moa   ehi   n    lat d</controlfield>
+		<controlfield tag="001">990040063470106381</controlfield>
+		<datafield tag="035" ind1=" " ind2=" ">
+			<subfield code="a">(MiU)004006347MIU01</subfield>
+		</datafield>
+		<datafield tag="020" ind1=" " ind2=" ">
+			<subfield code="a">8322430736</subfield>
+			<subfield code="a">8888888888</subfield>
+		</datafield>
+		<datafield tag="028" ind1="2" ind2="2">
+			<subfield code="a">PWM-8680</subfield>
+			<subfield code="b">Polsike Wydawn. Muzyczne</subfield>
+		</datafield>
+		<datafield tag="035" ind1=" " ind2=" ">
+			<subfield code="a">(RLIN)MIUG99-C817</subfield>
+		</datafield>
+		<datafield tag="035" ind1=" " ind2=" ">
+			<subfield code="a">(III)iiio31544307</subfield>
+		</datafield>
+		<datafield tag="035" ind1=" " ind2=" ">
+			<subfield code="a">(OCoLC)ocm39819963</subfield>
+		</datafield>
+		<datafield tag="040" ind1=" " ind2=" ">
+			<subfield code="a">MH-Mu</subfield>
+			<subfield code="c">MH-Mu</subfield>
+			<subfield code="d">MiU</subfield>
+		</datafield>
+		<datafield tag="041" ind1="0" ind2=" ">
+			<subfield code="a">latcze</subfield>
+			<subfield code="g">czeenggerpol</subfield>
+		</datafield>
+		<datafield tag="100" ind1="1" ind2=" ">
+			<subfield code="a">Wilhelmi de Grudencz, Petrus,</subfield>
+			<subfield code="d">approximately 1400-approximately 1480.</subfield>
+			<subfield code="0">http://id.loc.gov/authorities/names/no95005776</subfield>
+			<subfield code="0">http://viaf.org/viaf/39567283</subfield>
+		</datafield>
+		<datafield tag="240" ind1="1" ind2="0">
+			<subfield code="a">Works.</subfield>
+			<subfield code="f">1993</subfield>
+		</datafield>
+		<datafield tag="245" ind1="1" ind2="0">
+			<subfield code="a">Opera musica /</subfield>
+			<subfield code="c">Petrus Wilhelmi de Grudencz, magister Cracoviensis ; edidit JaromÃ­r CÌernÃ½.</subfield>
+		</datafield>
+		<datafield tag="250" ind1=" " ind2=" ">
+			<subfield code="a">Wyd. 1.</subfield>
+		</datafield>
+		<datafield tag="260" ind1=" " ind2=" ">
+			<subfield code="a">KrakÃ³ w :</subfield>
+			<subfield code="b">Polskie Wydawn. Muzyczne,</subfield>
+			<subfield code="c">1993.</subfield>
+		</datafield>
+		<datafield tag="300" ind1=" " ind2=" ">
+			<subfield code="a">1 score (146 p.) :</subfield>
+			<subfield code="b">facsims. ;</subfield>
+			<subfield code="c">31 cm.</subfield>
+		</datafield>
+		<datafield tag="500" ind1=" " ind2=" ">
+			<subfield code="a">Vocal music for 1-5 voices.</subfield>
+		</datafield>
+		<datafield tag="546" ind1=" " ind2=" ">
+			<subfield code="a">Words in Latin and Czech.</subfield>
+		</datafield>
+		<datafield tag="546" ind1=" " ind2=" ">
+			<subfield code="a">Introd. in Polish, Czech and German; editorial notes in English.</subfield>
+		</datafield>
+		<datafield tag="650" ind1=" " ind2="0">
+			<subfield code="a">Vocal music.</subfield>
+			<subfield code="0">http://id.loc.gov/authorities/subjects/sh85144088</subfield>
+		</datafield>
+		<datafield tag="650" ind1=" " ind2="0">
+			<subfield code="a">Motets.</subfield>
+			<subfield code="0">http://id.loc.gov/authorities/subjects/sh85087515</subfield>
+		</datafield>
+		<datafield tag="700" ind1="1" ind2=" ">
+			<subfield code="a">ÄernÃ½, JaromÃ­ r,</subfield>
+			<subfield code="d">1939-</subfield>
+			<subfield code="0">http://id.loc.gov/authorities/names/n84100249</subfield>
+			<subfield code="0">http://viaf.org/viaf/52115348</subfield>
+		</datafield>
+		<datafield tag="998" ind1=" " ind2=" ">
+			<subfield code="c">LMH</subfield>
+			<subfield code="s">9114</subfield>
+		</datafield>
+		<datafield tag="958" ind1=" " ind2=" ">
+			<subfield code="a">MiU</subfield>
+		</datafield>
+		<datafield tag="959" ind1=" " ind2=" ">
+			<subfield code="a">(notis)ULBAM3997</subfield>
+		</datafield>
+		<datafield tag="995" ind1=" " ind2=" ">
+			<subfield code="a">20</subfield>
+		</datafield>
+		<datafield tag="BIB" ind1=" " ind2=" ">
+			<subfield code="u">2022-08-15 04:23:45 US/Eastern</subfield>
+			<subfield code="c">2021-06-21 18:24:57 US/Eastern</subfield>
+			<subfield code="s">false</subfield>
+		</datafield>
+		<datafield tag="852" ind1="0" ind2=" ">
+			<subfield code="b">MUSIC</subfield>
+			<subfield code="a">MiU</subfield>
+			<subfield code="c">NONE</subfield>
+			<subfield code="h">M 3 .P52 1993</subfield>
+			<subfield code="8">22975380140006381</subfield>
+		</datafield>
+		<datafield tag="974" ind1=" " ind2=" ">
+			<subfield code="8">22975380140006381</subfield>
+			<subfield code="f">1</subfield>
+			<subfield code="c">NONE</subfield>
+			<subfield code="m">SCORE</subfield>
+			<subfield code="a">39015040218748</subfield>
+			<subfield code="e">NONE</subfield>
+			<subfield code="u">mdp.39015040218748 ic 20201202</subfield>
+			<subfield code="7">23975380130006381</subfield>
+			<subfield code="p">08</subfield>
+			<subfield code="r">1998-12-16 05:59:00 US/Eastern</subfield>
+			<subfield code="h">M 3 .P52 1993</subfield>
+			<subfield code="d">MUSIC</subfield>
+			<subfield code="b">MUSIC</subfield>
+		</datafield>
+	</record>
+</collection>

--- a/umich_catalog_indexing/spec/indexers/common_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/common_spec.rb
@@ -1,0 +1,23 @@
+describe "indexers common" do
+  let(:indexer) do
+    Traject::Indexer.new do
+      load_config_file("./spec/support/traject_settings.rb")
+      load_config_file("./indexers/common.rb")
+    end
+  end
+  before(:each) do
+    @record = get_record("spec/fixtures/grudencz.xml")
+  end
+  subject do
+    indexer.process_record(@record).output_hash
+  end
+  context "language" do
+    it "gets language from 008 and 041" do
+      expect(subject["language"]).to contain_exactly("Latin", "Czech")
+    end
+    it "ignores languages that have a subfield 2 in 041" do
+      @record["041"].append(MARC::Subfield.new("2", "some_value"))
+      expect(subject["language"]).to contain_exactly("Latin")
+    end
+  end
+end

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -1,11 +1,5 @@
 require "traject"
 describe "umich_alma" do
-  def get_record(path)
-    reader = MARC::XMLReader.new(path)
-    for r in reader
-      return r
-    end
-  end
   let(:hurdy_gurdy) do
     get_record("./spec/fixtures/hurdy_gurdy.xml")
   end

--- a/umich_catalog_indexing/spec/spec_helper.rb
+++ b/umich_catalog_indexing/spec/spec_helper.rb
@@ -30,3 +30,7 @@ end
 def fixture(path)
   File.read("./spec/fixtures/#{path}")
 end
+
+def get_record(path)
+  MARC::XMLReader.new(path).first
+end

--- a/umich_catalog_indexing/spec/traject/umich/digital_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/digital_holding_spec.rb
@@ -1,14 +1,8 @@
 require "traject"
 require "umich_traject"
 describe Traject::UMich::DigitalHolding do
-  def get_record(path)
-    reader = MARC::XMLReader.new(path)
-    for r in reader
-      return r
-    end
-  end
   let(:arborist) do
-    get_record('./spec/fixtures/arborist_avd.xml')
+    get_record("./spec/fixtures/arborist_avd.xml")
   end
   let(:avd) do
     arborist.fields("AVD").first
@@ -48,7 +42,7 @@ describe Traject::UMich::DigitalHolding do
   end
   context "#to_h" do
     it "returns expected hash" do
-      expect(subject.to_h).to eq( 
+      expect(subject.to_h).to eq(
         {
           library: "ALMA_DIGITAL",
           link: "https://umich-psb.alma.exlibrisgroup.com/discovery/delivery/01UMICH_INST:UMICH/121230624780006381",
@@ -61,4 +55,3 @@ describe Traject::UMich::DigitalHolding do
     end
   end
 end
-

--- a/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
@@ -1,9 +1,6 @@
 require "traject"
 require "umich_traject"
 describe Traject::UMich::ElectronicHolding do
-  def get_record(path)
-    MARC::XMLReader.new(path).first
-  end
   let(:e_resource) do
     get_record("./spec/fixtures/e_resource.xml")
   end

--- a/umich_catalog_indexing/spec/traject/umich/physical_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/physical_holding_spec.rb
@@ -1,21 +1,15 @@
 require "traject"
 require "umich_traject"
 describe Traject::UMich::PhysicalHolding do
-  def get_record(path)
-    reader = MARC::XMLReader.new(path)
-    for r in reader
-      return r
-    end
-  end
   let(:arborist) do
-    get_record('./spec/fixtures/arborist.xml')
+    get_record("./spec/fixtures/arborist.xml")
   end
   let(:holding_id) { "22767949280006381" }
   before(:each) do
     @record = arborist
   end
   subject do
-    described_class.new(record: @record, holding_id: holding_id) 
+    described_class.new(record: @record, holding_id: holding_id)
   end
   context "#institution_code" do
     it "returns upcased institution code" do
@@ -65,7 +59,7 @@ describe Traject::UMich::PhysicalHolding do
           when "c"
             s.value = "GRAD"
           when "h"
-            s.value = nil 
+            s.value = nil
           end
         end
       end
@@ -91,7 +85,7 @@ describe Traject::UMich::PhysicalHolding do
     it "is true if any of the 974s have f=1" do
       expect(subject.circulating?).to eq(true)
     end
-    it "is false if none of the 974s have f = 1" do 
+    it "is false if none of the 974s have f = 1" do
       @record.fields("974").each do |f|
         f.subfields.each do |s|
           s.value = "0" if s.code == "f"
@@ -115,7 +109,7 @@ describe Traject::UMich::PhysicalHolding do
       @record.fields("852").each do |f|
         f.subfields.each do |s|
           if s.code == "c"
-            s.value = nil 
+            s.value = nil
           end
         end
       end
@@ -123,7 +117,7 @@ describe Traject::UMich::PhysicalHolding do
       @record.fields("974").each do |f|
         f.subfields.each do |s|
           if s.code == "c"
-            s.value = nil 
+            s.value = nil
           end
         end
       end
@@ -140,7 +134,7 @@ describe Traject::UMich::PhysicalHolding do
       expect(subject.items.count).to eq(2)
     end
     it "doesn't include process type CA" do
-      @record["974"].append(MARC::Subfield.new("y","Process Status: CA"))
+      @record["974"].append(MARC::Subfield.new("y", "Process Status: CA"))
       expect(subject.items.count).to eq(1)
     end
   end
@@ -152,7 +146,7 @@ describe Traject::UMich::PhysicalHolding do
           s.value = "http://quod.lib.umich.edu/c/clementsead/umich-wcl-M-2015mit?view=text"
         end
       end
-      @record["856"].append(MARC::Subfield.new("y","Finding aid"))
+      @record["856"].append(MARC::Subfield.new("y", "Finding aid"))
       expect(subject.finding_aid?).to eq(true)
     end
     it "returns false if there isn't a Finding aid" do
@@ -162,8 +156,8 @@ describe Traject::UMich::PhysicalHolding do
   context "to_h" do
     it "returns a hash with the expected keys" do
       keys = [:callnumber, :display_name, :floor_location, :hol_mmsid,
-              :info_link, :items, :library, :location, :public_note,
-              :record_has_finding_aid, :summary_holdings]
+        :info_link, :items, :library, :location, :public_note,
+        :record_has_finding_aid, :summary_holdings]
       expect(subject.to_h.keys.sort).to eq(keys)
     end
   end

--- a/umich_catalog_indexing/spec/traject/umich/physical_item_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/physical_item_spec.rb
@@ -1,14 +1,8 @@
 require "traject"
 require "umich_traject"
 describe Traject::UMich::PhysicalItem do
-  def get_record(path)
-    reader = MARC::XMLReader.new(path)
-    for r in reader
-      return r
-    end
-  end
   let(:arborist) do
-    get_record('./spec/fixtures/arborist.xml')
+    get_record("./spec/fixtures/arborist.xml")
   end
   before(:each) do
     @item = arborist["974"]
@@ -136,7 +130,7 @@ describe Traject::UMich::PhysicalItem do
     it "returns only the library if there is no location" do
       @item.subfields.each do |s|
         if s.code == "c"
-          s.value = nil 
+          s.value = nil
         end
       end
       expect(subject.locations).to eq(["SHAP"])
@@ -157,21 +151,21 @@ describe Traject::UMich::PhysicalItem do
       expect(subject.should_be_suppressed).to eq(false)
     end
     it "is true for process status CA" do
-      @item.append(MARC::Subfield.new("y","Process Status: CA"))
+      @item.append(MARC::Subfield.new("y", "Process Status: CA"))
       expect(subject.should_be_suppressed).to eq(true)
     end
     it "is true for process status WN" do
-      @item.append(MARC::Subfield.new("y","Process Status: WN"))
+      @item.append(MARC::Subfield.new("y", "Process Status: WN"))
       expect(subject.should_be_suppressed).to eq(true)
     end
     it "is true for process status WD" do
-      @item.append(MARC::Subfield.new("y","Process Status: WD"))
+      @item.append(MARC::Subfield.new("y", "Process Status: WD"))
       expect(subject.should_be_suppressed).to eq(true)
     end
     it "is true when library is ELEC" do
       @item.subfields.each do |s|
         if s.code == "b"
-          s.value = "ELEC" 
+          s.value = "ELEC"
         end
       end
       expect(subject.should_be_suppressed).to eq(true)
@@ -179,7 +173,7 @@ describe Traject::UMich::PhysicalItem do
     it "is true when library is SDR" do
       @item.subfields.each do |s|
         if s.code == "b"
-          s.value = "SDR" 
+          s.value = "SDR"
         end
       end
       expect(subject.should_be_suppressed).to eq(true)
@@ -188,13 +182,11 @@ describe Traject::UMich::PhysicalItem do
   context "#to_h" do
     it "returns a hash with the expected keys" do
       keys = [:barcode, :callnumber, :can_reserve, :description, :display_name,
-              :fulfillment_unit, :info_link, :inventory_number, :item_id,
-              :item_policy, :library, :location, :permanent_library,
-              :permanent_location, :process_type, :public_note,
-              :record_has_finding_aid, :temp_location, :location_type, :material_type
-      ]
+        :fulfillment_unit, :info_link, :inventory_number, :item_id,
+        :item_policy, :library, :location, :permanent_library,
+        :permanent_location, :process_type, :public_note,
+        :record_has_finding_aid, :temp_location, :location_type, :material_type]
       expect(subject.to_h.keys.sort).to eq(keys.sort)
     end
   end
 end
-


### PR DESCRIPTION
This PR address [LIBSEARCH-944](https://mlit.atlassian.net/browse/LIBSEARCH-944)

* Tidies the specs by moving the `get_record` function into `spec_helper`.
* For the language field, this skips non control fields with a subfield 2 value. In this case the only one is 041.

The code for handling languages comes directly from the [marc21_semantics macros](https://github.com/traject/traject/blob/main/lib/traject/macros/marc21_semantics.rb).