### PR TITLE
fix: interface_name should not return None

### DIFF
--- a/umich_catalog_indexing/lib/jobs/translation_map_generator/electronic_collections.rb
+++ b/umich_catalog_indexing/lib/jobs/translation_map_generator/electronic_collections.rb
@@ -94,7 +94,8 @@ module Jobs
         end
 
         def interface_name
-          preferred_value("Electronic Collection Interface Name")
+          i_name = preferred_value("Electronic Collection Interface Name")
+          (i_name == "None") ? "" : i_name
         end
 
         # Concatentates interface name, public note, and authentication note.

--- a/umich_catalog_indexing/spec/jobs/translation_map_generator/electronic_collections_spec.rb
+++ b/umich_catalog_indexing/spec/jobs/translation_map_generator/electronic_collections_spec.rb
@@ -119,6 +119,11 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::Item do
       @item["Electronic Collection Interface Name (override)"] = nil
       expect(subject.interface_name).to eq("INTERFACE")
     end
+    it "returns empty when the Interface Name is None and Inverface Name (override) is empty" do
+      @item["Electronic Collection Interface Name (override)"] = nil
+      @item["Electronic Collection Interface Name"] = "None"
+      expect(subject.interface_name).to eq("")
+    end
   end
   context "#note" do
     it "returns the Interface name. Public Note. Authentication Note. when they all exist" do
@@ -134,7 +139,7 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::Item do
       @item["Electronic Collection Authentication Note"] = nil
       @item["Electronic Collection Public Note"] = nil
       @item["Electronic Collection Interface Name (override)"] = nil
-      @item["Electronic Collection Interface Name"] = nil
+      @item["Electronic Collection Interface Name"] = "None"
       expect(subject.note).to eq("")
     end
     it "gets replaces non period punctuation with periods. It leaves closing parens and square brackets" do


### PR DESCRIPTION
The electronic-collections analytics report returns "None" for interface names that don't have a value. We want to treat "None" as an empty string so that the word "None" doesn't show up in Search.