### PR TITLE
Fix sidekiq timeout errors

### DIFF
--- a/umich_catalog_indexing/Gemfile.lock
+++ b/umich_catalog_indexing/Gemfile.lock
@@ -43,8 +43,8 @@ GEM
     byebug (11.1.3)
     canister (0.9.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     crack (0.4.5)
       rexml
     declarative (0.0.20)
@@ -115,6 +115,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
+    logger (1.6.5)
     marc (1.2.0)
       rexml
       scrub_rb (>= 1.0.1, < 2)
@@ -154,10 +155,10 @@ GEM
       method_source (~> 1.0)
     public_suffix (5.0.4)
     racc (1.7.3)
-    rack (3.0.8)
+    rack (3.1.8)
     rainbow (3.1.1)
     rake (13.1.0)
-    redis-client (0.19.1)
+    redis-client (0.23.2)
       connection_pool
     regexp_parser (2.9.0)
     representable (3.2.0)
@@ -202,11 +203,12 @@ GEM
       concurrent-ruby (~> 1.0)
     sequel (5.76.0)
       bigdecimal
-    sidekiq (7.2.0)
-      concurrent-ruby (< 2)
+    sidekiq (7.3.8)
+      base64
       connection_pool (>= 2.3.0)
+      logger
       rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+      redis-client (>= 0.22.2)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)


### PR DESCRIPTION
Sidekiq has had timeout errors for the past few days. Per: https://github.com/sidekiq/sidekiq/issues/6162 I might need to update the timeout range.

First we're trying updating sidekiq. 

ETA: an image with the latest sidekiq version ran in the reindex containers for a day, and didn't have any timeout errors. I think this is enough. 