### PR TITLE
Update the test for ejournal?

### DIFF
--- a/umich_catalog_indexing/indexers/umich_alma.rb
+++ b/umich_catalog_indexing/indexers/umich_alma.rb
@@ -172,9 +172,8 @@ end
 #
 
 def ejournal?(context)
-  elec = context.clipboard[:ht][:hol_list].any? { |hol| hol[:library]&.include? "ELEC" }
-  form = context.output_hash["format"]
-  elec and form&.include?("Serial")
+  context.clipboard[:ht][:locations]&.include?("ELEC") &&
+    context.output_hash["format"]&.include?("Serial")
 end
 
 FILING_TITLE_880_extractor = Traject::MarcExtractor.new("245abdefgknp", alternate_script: :only)


### PR DESCRIPTION
title_initial checks ejournal?, which should match the solr query +location:ELEC +format:Serial.

Instead this was matching on library name within holdings.

This commit realigns the ejournal? check.