### PR TITLE
Fix Online Journals

### DIFF
--- a/umich_catalog_indexing/indexers/umich_alma.rb
+++ b/umich_catalog_indexing/indexers/umich_alma.rb
@@ -172,7 +172,7 @@ end
 #
 
 def ejournal?(context)
-  elec = context.clipboard[:ht][:hol_list].any? { |hol| hol[:library]&.include? "ELEC" }
+  elec = context.clipboard[:ht][:hol_list].any? { |hol| [hol[:library], hol["library"]].include? "ELEC" }
   form = context.output_hash["format"]
   elec and form&.include?("Serial")
 end


### PR DESCRIPTION
The `title_initial` was checking to see if any of the holdings of the item had the `:library` holding key equal to `ELEC`. Most of the holding keys were `"library"`. That is to say the key for most online journals is a `String` not a `Symbol`. 

Ideally we'd make these conform to one or the other, but that would involve adding tests on the part that's setting it to a `symbol` and I'm not feeling like I have time for that. This will fix the problem. 