### PR TITLE
collection_name must be empty string not nil

### DIFF
--- a/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
+++ b/umich_catalog_indexing/lib/umich_traject/electronic_holding.rb
@@ -49,7 +49,7 @@ module Traject
       end
 
       def collection_name
-        @e56["n"]
+        @e56["n"] || ""
       end
 
       def collection_id
@@ -77,7 +77,7 @@ module Traject
           collection_name,
           authentication_note,
           public_note
-        ].flatten.compact.map do |x|
+        ].flatten.reject { |x| x.to_s.empty? }.map do |x|
           out = x.strip
             .sub(/[[\p{P}]&&[^\])]]$/, "")
           out.sub!(/$/, ".") if out.match?(/[^\])]$/)

--- a/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/umich_alma_spec.rb
@@ -36,7 +36,7 @@ describe "umich_alma" do
 
         "finding_aid" => false,
         "authentication_note" => [],
-        "collection_name" => nil
+        "collection_name" => ""
       },
       {
         "finding_aid" => false,
@@ -53,7 +53,7 @@ describe "umich_alma" do
         "International Society of Arboriculture. Institutional password required for access to the International Society of Arboriculture online version; authentication required.",
         "status" => "Available",
         "authentication_note" => [],
-        "collection_name" => nil
+        "collection_name" => ""
       },
       {
         "callnumber" => "SB 435 .A71",

--- a/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
+++ b/umich_catalog_indexing/spec/traject/umich/electronic_holding_spec.rb
@@ -103,6 +103,10 @@ describe Traject::UMich::ElectronicHolding do
     it "show the collection_name from subfield n" do
       expect(subject.collection_name).to eq("Elsevier SD eBook - Physics and Astronomy")
     end
+    it "is an empty string if there is no collection name" do
+      @e56.subfields.delete_if { |x| x.code == "n" }
+      expect(subject.collection_name).to eq("")
+    end
   end
   context "#authentication_note" do
     it "shows the authentication note from subfield 4" do
@@ -118,6 +122,11 @@ describe Traject::UMich::ElectronicHolding do
       @e56.subfields.find { |x| x.code == "4" }.value = "[Square]"
       @e56.subfields.find { |x| x.code == "n" }.value = "Ends in semicolon;"
       expect(subject.note).to eq("Elsevier ScienceDirect. Ends in semicolon. [Square] (Parens)")
+    end
+
+    it "handles empty collection_name field" do
+      @e56.subfields.delete_if { |x| x.code == "n" }
+      expect(subject.note).to eq("Elsevier ScienceDirect. Authorized U-M users (+ guests in U-M Libraries) Public note.")
     end
   end
   context "#status" do


### PR DESCRIPTION
The code for ordering electronic records sorts first based on collection name, and then based on the ranking. Sometimes collection name is nil in the record. This code makes it an empty string.