### PR TITLE
add campuses and groups to electronic collections

### DIFF
--- a/umich_catalog_indexing/indexers/umich_alma.rb
+++ b/umich_catalog_indexing/indexers/umich_alma.rb
@@ -102,6 +102,7 @@ each_record do |r, context|
     if electronic_collections_for_id
 
       hol_list = electronic_collections_for_id.map do |x|
+        inst_codes.push(*x["institution_codes"])
         {
           link: x["link"],
           library: "ELEC",
@@ -110,7 +111,8 @@ each_record do |r, context|
           note: x["note"],
           collection_name: x["collection_name"],
           interface_name: x["interface_name"],
-          finding_aid: false
+          finding_aid: false,
+          campuses: x["campuses"]
         }
       end
       locations << "ELEC"

--- a/umich_catalog_indexing/lib/jobs/translation_map_generator/electronic_collections.rb
+++ b/umich_catalog_indexing/lib/jobs/translation_map_generator/electronic_collections.rb
@@ -56,6 +56,10 @@ module Jobs
       end
 
       class Item
+        CAMPUS_TO_INST_CODE = {
+          "ann_arbor" => "MIU",
+          "flint" => "MIFLIC"
+        }
         def self.for(data)
           if data["Electronic Collection Level URL (override)"] || data["Electronic Collection Level URL"]
             AvailableItem.new(data)
@@ -82,6 +86,20 @@ module Jobs
         # do anything with the Collection ID.
         def collection_id
           @data["Electronic Collection Id"]
+        end
+
+        def campuses
+          @data["Available For Group"]
+            &.split("; ")
+            &.map { |x| x.downcase.strip.sub("\s", "_") } || CAMPUS_TO_INST_CODE.keys
+        end
+
+        def institution_codes
+          if campuses.nil?
+            CAMPUS_TO_INST_CODE.values
+          else
+            campuses.map { |x| CAMPUS_TO_INST_CODE[x] }
+          end
         end
 
         def link
@@ -122,7 +140,9 @@ module Jobs
             "interface_name",
             "note",
             "link",
-            "status"
+            "status",
+            "campuses",
+            "institution_codes"
           ].map do |x|
             [x, send(x)]
           end.to_h

--- a/umich_catalog_indexing/lib/translation_maps/umich/electronic_collections.yaml
+++ b/umich_catalog_indexing/lib/translation_maps/umich/electronic_collections.yaml
@@ -5,5783 +5,11450 @@
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/agricenvironm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990135382470106381':
 - collection_name: Kanopy Streaming Service - Ann Arbor Campus
   interface_name: Kanopy
   note: Kanopy. Ann Arbor. Access to films not already licensed is mediated. You may be prompted to make a request for a film to be added. Authorized U-M users (+ guests in U-M Libraries)
   link: https://umich.kanopystreaming.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 - collection_name: Kanopy Streaming Service - Flint Campus
   interface_name: Kanopy
   note: Kanopy. Flint. Access to films not already licensed is mediated. You may be prompted to make a request for a film to be added. Authorized UM-Flint users (+ guests in the Thompson Library)
   link: https://www.kanopy.com/en/umflint/
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '990135302770106381':
 - collection_name: 'MarinLit : a database of the marine natural products literature /'
   interface_name: Royal Society of Chemistry
   note: Royal Society of Chemistry. Authorized U-M users (+ guests in U-M Libraries)
   link: https://marinlit.rsc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990093544650106381':
 - collection_name: African-American newspapers, 1827-1998
   interface_name: NewsBank
-  note: NewsBank. Access to the NewsBank online version restricted; authentication may be required.
+  note: NewsBank. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infoweb.newsbank.com/?db=EANX&d_collections=EANAAA%7CEANAAA2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121606470106381':
 - collection_name: African American periodicals, 1825-1995
   interface_name: NewsBank
-  note: NewsBank. Access to the NewsBank online version restricted; authentication may be required.
+  note: NewsBank. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infoweb.newsbank.com/?db=EAPX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121606440106381':
 - collection_name: Afro-Americana imprints, 1535-1922
   interface_name: NewsBank
   note: NewsBank. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.lib.umich.edu/database/link/11775
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990129130720106381':
 - collection_name: ProQuest congressional publications.
   interface_name: ProQuest Congressional Publications
   note: ProQuest Congressional Publications. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/basic/basicsearch?
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990129130070106381':
 - collection_name: The women's wear daily archive.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/wwd?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990096615660106381':
 - collection_name: TLS historical archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infotrac.galegroup.com/itweb/umuser?db=TLSH
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990146270750106381':
 - collection_name: The Oxford companion to music /
   interface_name: Oxford Reference
   note: Oxford Reference. Access to the Oxford Reference online version restricted; authentication may be required. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordreference.com/view/10.1093/acref/9780199579037.001.0001/acref-9780199579037
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990148943610106381':
 - collection_name: Zhonghua jing dian gu ji ku.
   interface_name: Zhonghua ancient books database
   note: Zhonghua ancient books database. Access to the Zhonghua ancient books database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/42272
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990148943560106381':
 - collection_name: 'CNKI : Zhongguo zheng bao gong bao qi kan wen xian zong ku.'
   interface_name: ''
   note: Access to this database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/42298
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113612690106381':
 - collection_name: 'CiNii Articles : NII scholarly and academic information navigator'
   interface_name: ''
   note: ''
   link: http://ci.nii.ac.jp/ja
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113973200106381':
 - collection_name: Women's studies international
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fyh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113973140106381':
 - collection_name: Wildlife & ecology studies worldwide
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fzh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113973050106381':
 - collection_name: Violence & abuse abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=28h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113889090106381':
 - collection_name: Race relations abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=25h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113881740106381':
 - collection_name: Global health
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=lhh&defaultdb=gha
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990113881730106381':
 - collection_name: Gender studies database
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fmh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049093290106381':
 - collection_name: Informations- und Dokumentationsstelle / Genderbibliothek
   interface_name: Zentrum für transdisziplinäre Geschlechterstudien
   note: Zentrum für transdisziplinäre Geschlechterstudien.
   link: https://www.meta-katalog.eu/Search/Results?limit=20&filter%255B%255D=institution%253AGenderbibliothek
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049081720106381':
 - collection_name: The world Shakespeare bibliography online
   interface_name: World Shakespeare Bibliography
   note: World Shakespeare Bibliography. Access to the World Shakespeare Bibliography Online online version restricted ; authentication may be required.
   link: http://www.worldshakesbib.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049670050106381':
 - collection_name: Historic documents.
   interface_name: SAGE
   note: SAGE. Access to the SAGE online version restricted; authentication may be required.
   link: http://dx.doi.org/10.4135/9781483380506
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Historic documents.
   interface_name: SAGE
   note: SAGE. Access to the SAGE online version restricted; authentication may be required.
   link: http://dx.doi.org/10.4135/9781506333496
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Historic documents.
   interface_name: SAGE
   note: SAGE. Access to the SAGE online version restricted; authentication may be required.
   link: http://dx.doi.org/10.4135/9781506374383
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049687040106381':
 - collection_name: Empire Online
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.empire.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049660880106381':
 - collection_name: Heilbrunn timeline of art history
   interface_name: Metropolitan Museum of Art
   note: Metropolitan Museum of Art. Access to the Metropolitan Museum of Art online version.
   link: http://www.metmuseum.org/toah/splash.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990024674950106381':
 - collection_name: 'Bibliography of the history of art : BHA = Bibliographie d''histoire de l''art.'
   interface_name: Getty Art History Information Program
   note: Getty Art History Information Program. Access to the Getty Art History Information Program online version.
   link: http://hdl.handle.net/10020/bha
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040725940106381':
 - collection_name: The American heritage dictionary of the English language
   interface_name: American Heritage Dictionary
   note: American Heritage Dictionary. Open access for all users.
   link: https://www.ahdictionary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040693670106381':
 - collection_name: Dartmouth Dante project
   interface_name: Dartmouth College
-  note: Dartmouth College. Access to the Dartmouth College online version.
+  note: Dartmouth College. Authorized U-M users (+ guests in U-M Libraries)
   link: http://dante.dartmouth.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040668830106381':
 - collection_name: Musical America worldwide.
   interface_name: online
   note: online. Access to the online version restricted to 5 concurrent users; authentication may be required.
   link: https://www.musicalamerica.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043368940106381':
 - collection_name: UN comtrade.
   interface_name: United Nations
   note: United Nations. Access to the United Nations online version restricted; authentication may be required.
   link: http://comtrade.un.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990084393110106381':
 - collection_name: FDA notices of judgment collection, 1906-1964
   interface_name: ''
   note: ''
   link: http://archive.nlm.nih.gov/fdanj/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990182940190106381':
 - collection_name: a+t online library.
   interface_name: a+t architecture publishers
   note: a+t architecture publishers. 5 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://aplust.net/area-privada/biblioteca-digital/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990182937410106381':
 - collection_name: Russian Islamic studies.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/1890
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990140339870106381':
 - collection_name: Taylor & Francis online journals
   interface_name: Taylor & Francis
   note: Taylor & Francis. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.tandfonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990122207860106381':
 - collection_name: IBISWorld.
   interface_name: IBISWorld
   note: IBISWorld. Authorized U-M users (+ guests in U-M Libraries)
   link: https://my.ibisworld.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161282990106381':
 - collection_name: Early Arabic printed books from the British Library (1475-1900) = Umahāt al-kutub al-ʻArabīyah al-maṭbūʻah min al-maktabah al-Birīṭānīyah.
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infotrac.galegroup.com/itweb/umuser?db=EAPB
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990140273820106381':
 - collection_name: Alexander Street
   interface_name: Alexander Street Press
   note: Alexander Street Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
+- collection_name: Alexander Street
+  interface_name: Alexander Street Press
+  note: Alexander Street Press. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://search.alexanderstreet.com
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990137867710106381':
 - collection_name: JSTOR Primary Sources
   interface_name: JSTOR
   note: JSTOR. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jstor.org/site/primary-sources/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990058999180106381':
 - collection_name: The Global library of women's medicine
   interface_name: GLOWM
   note: GLOWM. Access to the GLOWM online version.
   link: http://www.glowm.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990152201870106381':
 - collection_name: Russian governmental publications.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/5
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990124736780106381':
 - collection_name: MyWorldAbroad
   interface_name: Intercultural Systems/Systèmes interculturels (ISSI)
   note: Intercultural Systems/Systèmes interculturels (ISSI) Access to the Intercultural Systems/Systèmes interculturels (ISSI) online version restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/30716
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990103594710106381':
 - collection_name: SciFinder-n
   interface_name: ''
   note: Library research guide; instructions for account creation.
   link: https://guides.lib.umich.edu/scifinder
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: SciFinder-n
   interface_name: Chemical Abstracts Service
   note: Chemical Abstracts Service. Access requires personal registration. Authorized U-M users (+ guests in U-M Libraries)
   link: https://scifinder-n.cas.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990149915250106381':
 - collection_name: NEJM resident 360
   interface_name: New England journal of medicine
   note: New England journal of medicine. Information page. Discontinued as of January 15, 2025. See NEJM Group publication websites for relevant content.
   link: http://resident360.nejm.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176825640106381':
-- collection_name: Birds of the world /
+- collection_name: Birds of the world
   interface_name: Cornell Lab of Ornithology
-  note: Cornell Lab of Ornithology. Access to the Cornell Lab of Ornithology online version restricted; authentication may be required.
+  note: Cornell Lab of Ornithology. Authorized U-M users (+ guests in U-M Libraries)
   link: https://birdsoftheworld.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176679430106381':
 - collection_name: Integrum.
   interface_name: Integrum Media
   note: Integrum Media. Access to the Integrum Media online version restricted; authentication may be required; Select "Enter (no registration)".
   link: http://aclient.integrum.ru/gate/?name=unmich
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121638240106381':
 - collection_name: Naxos video library
   interface_name: Naxos Digital Services
   note: Naxos Digital Services. Access to the Naxos Digital Services online version restricted; authentication may be required. Authorized U-M users (+ guests in U-M Libraries)
   link: https://umich.naxosvideolibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990151778830106381':
 - collection_name: ASME standards collection.
   interface_name: American Society of Mechanical Engineers
   note: American Society of Mechanical Engineers. Access to the American Society of Mechanical Engineers online version restricted; authentication may be required; Select "Click here to access via institutional account" from top of page. Authorized U-M users (+ guests in U-M Libraries)
   link: http://asmestandardscollection.org/Login.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990139766460106381':
 - collection_name: Child welfare information gateway.
   interface_name: ''
   note: Archived site.
   link: http://purl.fdlp.gov/GPO/gpo61833
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990054099170106381':
 - collection_name: NASA Technical Reports Server (NTRS)
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.access.gpo.gov/GPO/LPS76746
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990051307810106381':
 - collection_name: World Bank e-Library.
   interface_name: World Bank Group
   note: World Bank Group.
   link: https://openknowledge.worldbank.org/home
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990047400850106381':
 - collection_name: Encyclopædia Iranica.
   interface_name: BrillOnline reference works
   note: BrillOnline reference works. Access to the BrillOnline reference works online version; Individual registration required to view illustrations.
   link: https://referenceworks.brillonline.com/browse/encyclopaedia-iranica-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Encyclopædia Iranica.
   interface_name: Encyclopædia Iranica Foundation
   note: Encyclopædia Iranica Foundation. Open access for all users.
   link: https://www.iranicaonline.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990042598190106381':
 - collection_name: Gutenberg-e
   interface_name: ''
   note: Access restricted ; authentication may be required.
   link: http://www.gutenberg-e.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033324430106381':
 - collection_name: National Criminal Justice Reference Service abstracts database
   interface_name: NCJRS
   note: NCJRS. Access to the NCJRS online version.
   link: http://www.ncjrs.gov/abstractdb/Search.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033257950106381':
 - collection_name: The philosophical gourmet report a ranking of graduate programs in philosophy in the English-speaking world /
   interface_name: PG
   note: PG. Access to the PG online version.
   link: http://www.philosophicalgourmet.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033248720106381':
 - collection_name: SCIPIO art and rare books sales catalogs.
   interface_name: OCLC FirstSearch
   note: OCLC FirstSearch. Access to the OCLC FirstSearch online version restricted; authentication may be required.
   link: http://firstsearch.oclc.org/dbname=SCIPIO;FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033248250106381':
 - collection_name: ArchiveGrid
   interface_name: OCLC
   note: OCLC. Access to the OCLC online version restricted; authentication may be required.
   link: https://beta.worldcat.org/archivegrid/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033245310106381':
 - collection_name: TOXLINE
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/toxline
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033236190106381':
 - collection_name: Electronic collections online
   interface_name: ''
   note: Access to the OCLC online version restricted (authentication may be required)
   link: http://firto%20the%20OCLC%20ostsearch.oclc.org/dbname=ECO;FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033234850106381':
 - collection_name: History of science, technology & medicine
   interface_name: EBSCO
   note: EBSCO. Access to the EBSCO online version restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/8291
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033234840106381':
 - collection_name: English short title catalogue ESTC.
   interface_name: ESTC
   note: ESTC. Access to the ESTC Online version.
   link: http://estc.bl.uk/
   status: Available
-'990005222060106381':
-- collection_name: International political science abstracts.
-  interface_name: EBSCOhost
-  note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
-  link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ijh
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005213580106381':
 - collection_name: Sociological abstracts.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/socabs/accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990111558840106381':
 - collection_name: Zhongguo su wen ku
   interface_name: Zhongguo su wen ku
   note: Zhongguo su wen ku. 2 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.lib.umich.edu/database/link/38889
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990111558780106381':
 - collection_name: Zhongguo fang zhi ku
   interface_name: Zhongguo fang zhi ku
   note: 'Zhongguo fang zhi ku. Access to the Zhongguo fang zhi ku restricted; authentication may be required: limit to two concurrent users.'
   link: http://www.lib.umich.edu/database/link/31235
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990147728310106381':
 - collection_name: GeoRef.
   interface_name: Engineering Village
   note: Engineering Village. Access to the Engineering Village online version restricted; authentication may be required.
   link: https://www.engineeringvillage.com/search/quick.url?database=2097152
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052396940106381':
 - collection_name: America's historical newspapers including Early American newspapers series, 1, 2, 3, 6 and 7, 1690-1922 ; African American newspapers, 1827-1998 and Hispanic American newspapers, 1808-1980.
   interface_name: Readex
   note: Readex. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infoweb.newsbank.com/apps/readex/?p=EANX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990127237830106381':
 - collection_name: Minguo shi qi qi kan quan wen shu ju ku (1911-1949).
   interface_name: National index to Chinese newspapers and periodicals
   note: National index to Chinese newspapers and periodicals. Access limited to 5 concurrent user; Access to the National index to Chinese newspapers and periodicals online version restricted; Search for content; authentication may be required.
   link: http://www.lib.umich.edu/database/link/30872
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990089087530106381':
 - collection_name: Images from the History of Medicine
   interface_name: National Library of Medicine
   note: National Library of Medicine. Access to the National Library of Medicine online version.
   link: http://wwwihm.nlm.nih.gov/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990148541480106381':
 - collection_name: 'PhilPapers : philosophical research online /'
   interface_name: Philpapers
   note: Philpapers. Access to the Philpapers online version (some full text content may be unavailable)
   link: http://philpapers.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990094769590106381':
 - collection_name: FDsys
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.fdlp.gov/GPO/gpo2995
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990140933130106381':
 - collection_name: Han'guk Sahoe Kwahak Charyowŏn Korean Social Science Data Archive.
   interface_name: ''
   note: Authentication may be required; Internet Explorer recommend; Contact ask-korea@umich.edu for assistance.
   link: http://www.kossda.or.kr/eng/index_kossda.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990127660960106381':
 - collection_name: The Merck index online
   interface_name: Merck Index
   note: Merck Index. Access to the Merck Index Online version restricted; authentication may be required.
   link: https://www.rsc.org/Merck-Index/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990031773430106381':
 - collection_name: World development indicators.
   interface_name: World Bank
   note: World Bank. Open access for all users.
   link: http://data.worldbank.org/data-catalog/world-development-indicators
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047254350106381':
 - collection_name: Central and Eastern European Online Library
   interface_name: CEEOL
   note: CEEOL. Access to the CEEOL online version restricted ; authentication may be required.
   link: http://www.ceeol.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990041225510106381':
 - collection_name: IEEE Xplore
   interface_name: IEEE
   note: IEEE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ieeexplore.ieee.org/Xplore/home.jsp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041188890106381':
 - collection_name: The Faber poetry library
   interface_name: University of Michigan, Digital Library Platform & Services
   note: University of Michigan, Digital Library Platform & Services. Access to the University of Michigan, Digital Library Platform & Services online version restricted; authentication may be required.
   link: https://quod.lib.umich.edu/f/faber/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041233480106381':
 - collection_name: EBSCO eBook collection
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=nlebk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990115995810106381':
 - collection_name: World Christian database
   interface_name: Brill Academic Publishers
   note: Brill Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.worldchristiandatabase.org/wcd/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049572430106381':
 - collection_name: NYPL Digital Gallery
   interface_name: NYPL
   note: NYPL. Access to the NYPL online version.
   link: http://digitalgallery.nypl.org/nypldigital/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056285190106381':
 - collection_name: NIST chemistry webbook
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.access.gpo.gov/GPO/LPS87332
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056261180106381':
 - collection_name: Accessible archives primary source material from 18th & 19th century periodicals.
   interface_name: Accessible Archives
   note: Accessible Archives. Authorized U-M users (+ guests in U-M Libraries)
   link: https://history-commons.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990165176600106381':
 - collection_name: EPS China data = EPS shu ju ping tai.
   interface_name: EPS China Data
   note: EPS China Data. Access to the EPS China Data online version restricted; authentication may be required.
   link: http://olap.epsnet.com.cn
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: EPS China data = EPS shu ju ping tai.
   interface_name: EPS China Data
   note: EPS China Data. Access to the EPS China Data online restricted; authentication may be required.
   link: http://www.epschinadata.com/support.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: EPS China data = EPS shu ju ping tai.
   interface_name: EPS China Data
   note: EPS China Data. Access to the EPS China Data online restricted; authentication may be required; Select "Enter the databases" from top menu.
   link: http://www.epschinadata.com/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990165175140106381':
 - collection_name: Taiwan xin wen zhi hui wang.
   interface_name: this database
   note: this database. 1949-2006 ; Access to this database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/45884
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990092552630106381':
 - collection_name: Canadian poetry database
   interface_name: ''
   note: Access via ProQuest restricted; authentication may be required.
   link: http://collections.chadwyck.com/home/home_cp.jsp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990106727780106381':
 - collection_name: Bridgeman education
   interface_name: Bridgeman
   note: Bridgeman. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.bridgemaneducation.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990127127290106381':
 - collection_name: Skillsoft.
   interface_name: SkillSoft
   note: SkillSoft. Access to the SkillSoft online version restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/30652
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990127127180106381':
 - collection_name: Lexicons of Early Modern English LEME.
   interface_name: University of Toronto Libraries
   note: University of Toronto Libraries. Open access for all users.
   link: https://leme.library.utoronto.ca/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990076102090106381':
 - collection_name: Apabi shu zi zi yuan ping tai.
   interface_name: Apabi dian zi zi yuan ping tai
   note: Apabi dian zi zi yuan ping tai. Access to the Apabi dian zi zi yuan ping tai restricted; authentification may be required.
   link: https://apps.lib.umich.edu/database/link/10977
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990075522750106381':
 - collection_name: Daniels' orchestral music online
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: https://daniels-orchestral.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990075518370106381':
 - collection_name: The Responsa project
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: http://www.responsa.co.il/loginform.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990186094230106381':
 - collection_name: ACS In Focus Inaugural Collection
   interface_name: American Chemical Society
   note: American Chemical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://pubs.acs.org/series/infocus
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990186092580106381':
 - collection_name: Zhang Letian Lianmin Cun shu ju ku = Zhang Letian Fieldwork database.
   interface_name: Zhang Letian Fieldwork database
   note: Zhang Letian Fieldwork database. Access to the Zhang Letian Fieldwork database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/48380
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990137007700106381':
 - collection_name: MarketResearch.com academic
   interface_name: ''
   note: Access restricted; authentication may be required.
   link: http://www.academic.marketresearch.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990182421750106381':
 - collection_name: Quan guo bao kan suo yin = National index to Chinese newspapers & periodicals /
   interface_name: National index to Chinese newspapers and periodicals
   note: National index to Chinese newspapers and periodicals. Access limited to 5 concurrent user; Access to the National index to Chinese newspapers and periodicals online version restricted; Search for content; authentication may be required.
   link: http://www.lib.umich.edu/database/link/30872
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990137950980106381':
 - collection_name: NK pro.
   interface_name: selected features
   note: selected features. ​Access to selected features restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/40738
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990136327550106381':
 - collection_name: Zhonghua shu zi shu yuan. China digital library.
   interface_name: Apabi dian zi zi yuan ping tai
   note: Apabi dian zi zi yuan ping tai. Access to the Apabi dian zi zi yuan ping tai restricted; authentification may be required.
   link: http://www.apabi.com/michigan/?pid=foreign.paper&dt=Newspaper&db=newspaper&dc=1&hdc=1&hc=1&hpg=top&cult=CN
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990136324570106381':
 - collection_name: The Waterloo directory of English newspapers & periodicals, 1800-1900 /
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: http://english.victorianperiodicals.com/series3/index.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990059669860106381':
 - collection_name: Chao xing shu zi tu shu guan Chinamaxx digital library of Chinese e-books.
   interface_name: Chinamaxx Digital Libraries
   note: Chinamaxx Digital Libraries. Access to Chinamaxx Digital Libraries restricted; authentication may be required.
   link: http://www.chinamaxx.net
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990059627730106381':
 - collection_name: ASCE library
   interface_name: ASCE Library
   note: ASCE Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ascelibrary.org/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990004948550106381':
 - collection_name: Arts & humanities citation index.
   interface_name: Web of Science
   note: Web of Science. Access to the Web of Science online version restricted; authentication may be required.
   link: http://webofknowledge.com/?DestApp=WOS&editions=AHCI
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047670500106381':
 - collection_name: Russian national bibliography
   interface_name: ''
   note: ''
   link: http://biblio.ebiblioteka.ru/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005196540106381':
 - collection_name: 'Language and language behavior abstracts : LLBA /'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/llba/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047335220106381':
 - collection_name: Emergence of advertising in America, 1850-1920 John W. Hartman Center for Sales, Advertising & Marketing History /
   interface_name: Duke University
   note: Duke University. Authorized U-M users (+ guests in U-M Libraries)
   link: https://repository.duke.edu/dc/eaa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047335210106381':
 - collection_name: Digitale Bibliothek Deutscher Klassiker im WWW
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/dkv
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047335190106381':
 - collection_name: INIS database
   interface_name: IAEA
   note: IAEA. Access to the IAEA online version restricted ; authentication may be required.
   link: http://www.iaea.org/inis/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990006769420106381':
 - collection_name: The Writers directory.
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/i.do?p=BIC&u=umuser&id=GALE%7C0HQJ&v=2.1&it=aboutJournal
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990006780600106381':
 - collection_name: Social sciences citation index.
   interface_name: Web of Science
   note: Web of Science. Access to the Web of Science online version restricted; authentication may be required.
   link: http://webofknowledge.com/?DestApp=WOS&editions=SSCI
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041361700106381':
 - collection_name: The international plant names index
   interface_name: ''
   note: Accrss to the IPNI online version.
   link: http://www.ipni.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041340300106381':
 - collection_name: Michigan eLibrary
   interface_name: online
   note: online. Access to the online version.
   link: http://mel.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990123339180106381':
 - collection_name: ICSD web
   interface_name: ''
   note: Access via FIZ Karlsruhe restricted; authentication may be required.
   link: http://icsd.fiz-karlsruhe.de/icsd/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990133150640106381':
 - collection_name: Samuel Beckett digital manuscript project.
   interface_name: Samuel Beckett Digital Manuscript Project
   note: Samuel Beckett Digital Manuscript Project. Access to the Samuel Beckett Digital Manuscript Project online version restricted; authentication may be required.
   link: http://www.beckettarchive.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990178024480106381':
 - collection_name: NEJM journal watch.
   interface_name: Massachusetts Medical Society
   note: Massachusetts Medical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jwatch.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161346340106381':
 - collection_name: MapVault.
   interface_name: East View Geospatial
   note: East View Geospatial. Authorized U-M users (+ guests in U-M Libraries)
   link: https://apps.geospatial.com/MapVault/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990070998690106381':
 - collection_name: Hua yi xian shang tu shu guan = Airiti Library.
   interface_name: Airiti Library
   note: Airiti Library. Access to the Airiti Library restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/10723
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176384890106381':
 - collection_name: 'U.S. Energy Information Administration : independent statistics & analysis.'
   interface_name: ''
   note: All archived contents for United States Census 2020.
   link: http://purl.fdlp.gov/GPO/gpo129288
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'U.S. Energy Information Administration : independent statistics & analysis.'
   interface_name: ''
   note: Archived site.
   link: http://purl.fdlp.gov/GPO/gpo129287
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990059269420106381':
 - collection_name: R2 digital library
   interface_name: R2 digital library
   note: R2 digital library. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.r2library.com/default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990159984080106381':
 - collection_name: Linguistic Data Consortium.
   interface_name: Linguistic Data Consortium
   note: Linguistic Data Consortium. Access requires personal registration. Authorized U-M users (no guest access)
   link: https://catalog.ldc.upenn.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990170639740106381':
 - collection_name: BioCyc database collection.
   interface_name: SRI International
   note: SRI International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://biocyc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990182900470106381':
 - collection_name: 'BabelScores® : contemporary music online.'
   interface_name: BabelScores
   note: BabelScores. Access to the BabelScores online version restricted; authentication may be required.
   link: https://www.babelscores.com/welcome-dear-subs
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161736430106381':
 - collection_name: 'Nineteenth-century American drama : popular culture and entertainment, 1820-1900.'
   interface_name: Readex
   note: Readex. Access to the Readex online version restricted; authentication may be required.
   link: http://infoweb.newsbank.com/apps/readex?p=AMDRA19C
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161736370106381':
 - collection_name: American broadsides and ephemera.
   interface_name: Readex
   note: Readex. Access to the Readex online version restricted; authentication may be required.
   link: http://infoweb.newsbank.com/?db=ABEA
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176151060106381':
 - collection_name: Persian e-books Miras Maktoob.
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/view/serial/MMP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990078887160106381':
 - collection_name: Ren min ri bao dian zi ban
   interface_name: ''
   note: Access to the Ren min ri bao dian zi ban databaserestricted; authentication may be required.
   link: http://rmrb.egreenapple.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990078205620106381':
 - collection_name: SPIE eBooks
   interface_name: SPIE
   note: SPIE. Access to the SPIE online version restricted; authentication may be required.
   link: http://ebooks.spiedigitallibrary.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990054014270106381':
 - collection_name: House of Commons parliamentary papers
   interface_name: ''
   note: Access restricted ; authentication may be required.
   link: http://parlipapers.chadwyck.com/home.do
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990054254400106381':
 - collection_name: Business source complete
   interface_name: ''
   note: Connect to online database; access restricted to subscribers.
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=bth
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041925780106381':
 - collection_name: Thesaurus Linguae Graecae a digital library of Greek literature /
   interface_name: University of California, Irvine
   note: University of California, Irvine. Access to the University of California, Irvine online version restricted; Individual registration required; authentication may be required.
   link: https://stephanus.tlg.uci.edu/index.php%23login=true
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040195960106381':
 - collection_name: Microbiology abstracts. Section B, Bacteriology.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/microbiologyb
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040186300106381':
 - collection_name: The Chicano database
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=chd
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990040177980106381':
 - collection_name: 'TRID : the TRIS and ITRD database.'
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: http://trid.trb.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040177800106381':
 - collection_name: Russian Academy of Sciences bibliographies
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rsb
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040141930106381':
 - collection_name: FAOSTAT statistical database
   interface_name: FAOSTAT
   note: FAOSTAT. Access to the FAOSTAT online version.
   link: http://faostat.fao.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990000529970106381':
 - collection_name: Hapi, Hispanic American periodicals index.
   interface_name: UCLA
   note: UCLA. Access to the UCLA online version restricted (authentication may be required)
   link: http://hapi.ucla.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005009730106381':
 - collection_name: Reshimat ma'amarim be-madaʻe ha-Yahadut.
   interface_name: Jewish National and University Library
   note: Jewish National and University Library. Access to the Jewish National and University Library Online version.
   link: http://jnul.huji.ac.il/rambi/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990051233620106381':
 - collection_name: Scopus
   interface_name: Scopus
   note: Scopus. Access to Scopus restricted; authentication may be required.
   link: http://www.scopus.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990051219580106381':
 - collection_name: The complete works and letters of Jane Austen
   interface_name: InteLex
   note: InteLex. Access to the InteLex online version restricted; authentication may be required.
   link: http://pm.nlx.com/xtf/view?docId=austen/austen.00.xml
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990116607740106381':
 - collection_name: Newspapers of the North Caucasus, Abkhazia and South Ossetia
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: http://dlib.eastview.com/browse/udb/1210
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990116599070106381':
 - collection_name: Entertainment industry magazine archive
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/eima/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056371390106381':
 - collection_name: PEP Web
   interface_name: Psychoanalytic Electronic Publishing
   note: Psychoanalytic Electronic Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://pep-web.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161142650106381':
 - collection_name: K'oria Sŭk'alla.
   interface_name: Korea Scholar
   note: Korea Scholar. Access to the Korea Scholar online version restricted; authentication may be required.
   link: http://db.koreascholar.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161130700106381':
 - collection_name: Maruzen eBook Library.
   interface_name: Maruzen eBook Library
   note: Maruzen eBook Library. 1 concurrent user limit per title. Authorized U-M users (+ guests in U-M Libraries)
   link: https://elib.maruzen.co.jp/elib/html/BookList?6
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990154140430106381':
 - collection_name: 'LAPOP : Latin American Public Opinion Project.'
   interface_name: Latin American Public Opinion Project
   note: Latin American Public Opinion Project. Access to the Latin American Public Opinion Project restricted; authentication may be required.
   link: http://datasets.americasbarometer.org/database/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990058447920106381':
 - collection_name: Han ji dian zi wen xian zi liao ku
   interface_name: Scripta Sinica
   note: Scripta Sinica. Access to the Scripta Sinica restricted; authorization may be required.
   link: http://hanchi.ihp.sinica.edu.tw/ihp/hanji.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990162866200106381':
 - collection_name: Fortunoff video archive for Holocaust testimonies /
   interface_name: Yale University Library
   note: Yale University Library. Individual registration required for access to the Yale University Library online version; authentication may be required.
   link: https://www.lib.umich.edu/database/link/45667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990038834730106381':
 - collection_name: Mafteaḥ le-maʼamarim be-ʻIvrit.
   interface_name: University of Haifa Library
   note: University of Haifa Library. Access to the University of Haifa Library online version restricted; authentication may be required.
   link: https://haifa-primo.hosted.exlibrisgroup.com/primo-explore/search?vid=IHP&lang=en_US
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990004991300106381':
 - collection_name: Science citation index.
   interface_name: Web of Science
   note: Web of Science. Access to the Web of Science online version restricted; authentication may be required.
   link: http://webofknowledge.com/?DestApp=WOS&editions=SCI
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990169145090106381':
 - collection_name: 'Diao long : Zhong Ri gu ji quan wen zi liao ku.'
   interface_name: Diāo lóng
   note: Diāo lóng. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.lib.umich.edu/database/link/46512
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990091879190106381':
 - collection_name: 'CNKI : China knowledge resource integrated databases'
   interface_name: China Knowledge Resource Integrated Database
   note: China Knowledge Resource Integrated Database. Access to the China Knowledge Resource Integrated Database restricted; authentication may be required.
   link: https://apps.lib.umich.edu/database/link/48665
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990092479820106381':
 - collection_name: Cairn.info
   interface_name: Cairn
-  note: Cairn. Access to the Cairn online version restricted; authentication may be required.
+  note: Cairn. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.cairn.info/accueil.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990092476570106381':
 - collection_name: ChemSpider
   interface_name: Royal Society of Chemistry
   note: Royal Society of Chemistry. Access to the Royal Society of Chemistry online version.
   link: http://www.chemspider.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990091731890106381':
 - collection_name: Zephyr
   interface_name: ''
   note: ''
   link: http://libproxy.umflint.edu:2048/login?url=http://www.bvdep.com/en/ZEPHYR.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990136992770106381':
 - collection_name: Music industry data.
   interface_name: Music ID
   note: Music ID. Access to the Music ID online version (authentication may be required)
   link: http://musicid.academicrightspress.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990125386820106381':
 - collection_name: 'Index Religiosus : international bibliography of theology, church history and religious studies : IR.'
   interface_name: Brepolis
   note: Brepolis. Access to the Brepolis online version restricted; authentication may be required.
   link: http://cpps.brepolis.net/ir/search.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990055770360106381':
 - collection_name: Public health image library PHIL.
   interface_name: online
   note: online. Access to the online version.
   link: http://phil.cdc.gov/Phil/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Public health image library PHIL.
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.access.gpo.gov/GPO/LPS81894
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990055706700106381':
 - collection_name: Philosopher's index
   interface_name: CSA Illumina
   note: CSA Illumina. Access to the CSA Illumina online version restricted (authentication may be required)
   link: http://libproxy.umflint.edu:2048/login?url=http://csaweb116v.csa.com/ids70/quick_search.php?SID=i2eotnnhjkmrj80vc1mklo4616
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990162003750106381':
 - collection_name: DESTech Publications, Inc.
   interface_name: DEStech Publishing
   note: DEStech Publishing. Access to the DEStech Publishing online version restricted; authentication may be required.
   link: https://www.destechpub.com/ebooks/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990135911070106381':
 - collection_name: China economy, public policy, and security database.
   interface_name: China Economy, Public Policy, and Security Database
   note: China Economy, Public Policy, and Security Database. Access to the China Economy, Public Policy, and Security Database restricted; authentication may be required.
   link: http://proxy.lib.umich.edu/login?url=http://www.lib.umich.edu/database/link/39587
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990135910990106381':
 - collection_name: Soshoo sou shu
   interface_name: SOSHOO sou shu
   note: SOSHOO sou shu. Access to the SOSHOO sou shu restricted; authentication may be required.
   link: http://proxy.lib.umich.edu/login?url=http://www.lib.umich.edu/database/link/39589
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990135910960106381':
 - collection_name: 'Zhongguo zi xun hang infobank : China content provider.'
   interface_name: trials of China Infobank
   note: trials of China Infobank. Access to the trials of China Infobank restricted; authentication may be required.
   link: http://proxy.lib.umich.edu/login?url=http://www.lib.umich.edu/database/link/39591
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990099613600106381':
 - collection_name: Littérature de l'Océan Indien
   interface_name: Classiques Garnier Numérique
-  note: Classiques Garnier Numérique. Access to the Classiques Garnier Numérique online version restricted; authentication may be required.
+  note: Classiques Garnier Numérique. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.classiques-garnier.com/numerique-bases/index.php?module=App&action=FrameMain&colname=ColOceanIndien
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990079312230106381':
 - collection_name: HLAS online handbook of Latin American studies /
   interface_name: ''
   note: ''
   link: http://purl.access.gpo.gov/GPO/LPS32256
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: HLAS online handbook of Latin American studies /
   interface_name: ''
   note: ''
   link: http://purl.access.gpo.gov/GPO/LPS32255
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: HLAS online handbook of Latin American studies /
   interface_name: ''
   note: ''
   link: http://purl.access.gpo.gov/GPO/LPS121297
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990050668220106381':
 - collection_name: Communication & mass media complete
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ufh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990050668190106381':
 - collection_name: LGBT life with full text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=qth
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040331030106381':
 - collection_name: 'EEBO : early English books online /'
   interface_name: University of Michigan Library
   note: University of Michigan Library.
   link: https://quod.lib.umich.edu/e/eebogroup/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040407120106381':
 - collection_name: NewsLibrary
   interface_name: News Library
   note: News Library. Access to the News Library online version restricted (authentication may be required)
   link: https://www.newslibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990050991160106381':
 - collection_name: 'Europe 1450 to 1789 : encyclopedia of the early modern world /'
   interface_name: Gale Virtual Reference Library
   note: Gale Virtual Reference Library. Authorized U-M users (+ guests in U-M Libraries)
   link: http://libproxy.umflint.edu:2048/login?url=http://find.galegroup.com/gvrl/aboutEbook.do?prodId=GVRL&userGroupName=umuser&actionString=DO_DISPLAY_ABOUT_PAGE&eisbn=0684314231&searchType=PublicationSearchForm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990111932940106381':
 - collection_name: Brepols online.
   interface_name: Brepolis
   note: Brepolis. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.brepolsonline.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033127590106381':
 - collection_name: FirstSearch
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://newfirstsearch.oclc.org/FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043474480106381':
 - collection_name: SPIE digital library.
   interface_name: SPIE
   note: SPIE. Access to the SPIE online version restricted; authentication may be required.
   link: https://www.spiedigitallibrary.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990155077230106381':
 - collection_name: University of Michigan Great Lakes digital library.
   interface_name: University of Michigan, Digital Library Platform & Services
   note: University of Michigan, Digital Library Platform & Services. Access to the University of Michigan, Digital Library Platform & Services online version.
   link: https://quod.lib.umich.edu/g/glrr/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990140816130106381':
 - collection_name: Women's magazine archive.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/wma
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121844850106381':
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewsocialtrends.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewglobal.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewhispanic.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewforum.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewinternet.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://journalism.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.people-press.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Pew Research Center numbers, facts and trends shaping your world.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://pewresearch.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121857880106381':
 - collection_name: OnArchitecture
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.onarchitecture.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990121851700106381':
 - collection_name: College affordability and transparency center
   interface_name: US Department of Education
   note: US Department of Education. Access to the US Department of Education online version .
   link: http://collegecost.ed.gov/catc/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121849110106381':
 - collection_name: The Pew Forum on Religion & Public Life
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://pewforum.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121848830106381':
 - collection_name: Social & demographic trends
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://pewsocialtrends.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121848720106381':
 - collection_name: Project for Excellence in Journalism
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.journalism.org/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121844910106381':
 - collection_name: Pew Hispanic Center chronicling Latinos' diverse experiences in a changing America /
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewhispanic.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121844900106381':
 - collection_name: Pew Global Attitudes Project
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://pewglobal.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121844880106381':
 - collection_name: The Pew Research Center for the People and the Press
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.people-press.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121844710106381':
 - collection_name: The microfinance gateway
   interface_name: CGAP
-  note: CGAP. Access to the CGAP online version.
+  note: CGAP. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.microfinancegateway.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121787490106381':
 - collection_name: China Local Gazetteers
   interface_name: Wanfang Data Co,. Ltd.
   note: Wanfang Data Co,. Ltd. Access to the Wan fang Xin Fang zhi shu ju ku restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/38785
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990151916890106381':
 - collection_name: East View e-books.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/910
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990151907720106381':
 - collection_name: English-Corpora.org
   interface_name: English-Corpora.org
   note: English-Corpora.org. Access to the English-Corpora.org online version restricted; authentication may be required.
   link: https://www.english-corpora.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990151892030106381':
 - collection_name: 'KPM : Chosŏn ŏllon chŏngbo kiji.'
   interface_name: ''
   note: Full text available via Korea Media (access restricted; authentication may be required)
   link: http://www.lib.umich.edu/database/link/43372
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990060805180106381':
 - collection_name: Social explorer
   interface_name: ''
   note: Access to the Social Explorer online version restricted; authentication may be required.
   link: https://www.socialexplorer.com/explore-maps
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990060547000106381':
 - collection_name: 'Index translationum : Répertoire international des traductions. International bibliography of translations.'
   interface_name: ''
   note: ''
   link: http://portal.unesco.org/culture/en/ev.php-URL_ID=7810&URL_DO=DO_TOPIC&URL_SECTION=201.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990166763450106381':
 - collection_name: The dictionary of substances and their effects database.
   interface_name: Royal Society of Chemistry
   note: Royal Society of Chemistry. Access to the Royal Society of Chemistry online version restricted; authentication may be required.
   link: https://www.rsc.org/Publishing/CurrentAwareness/DOSE/DOSESearchPage.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990127495240106381':
 - collection_name: NATLEX
   interface_name: International Labour Organisation
   note: International Labour Organisation. Access to the International Labour Organisation online version.
   link: http://natlex.ilo.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056691230106381':
 - collection_name: Health technology assessment (HTA) database
   interface_name: Centre for Reviews and Dissemination
   note: Centre for Reviews and Dissemination. Access to the Centre for Reviews and Dissemination online version restricted; authentication may be required.
   link: https://www.crd.york.ac.uk/crdweb/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056690730106381':
 - collection_name: NHS economic evaluation database (NHS EED)
   interface_name: Centre for Reviews and Dissemination archived
-  note: Centre for Reviews and Dissemination archived. Access to the Centre for Reviews and Dissemination archived online version restricted; authentication may be required.
+  note: Centre for Reviews and Dissemination archived. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.crd.york.ac.uk/crdweb/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990033326560106381':
 - collection_name: Micromedex healthcare series
   interface_name: ''
   note: Access restricted (authentication may be required)
   link: http://www.lib.umich.edu/health-sciences-libraries/accessing-micromedex
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990024495620106381':
 - collection_name: Early American newspapers
   interface_name: online
   note: online. Access to the Readex online version restricted; authentication may be required.
   link: http://infoweb.newsbank.com/?db=EANX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990034439930106381':
 - collection_name: TOXNET (toxicology data network) /
   interface_name: National Library of Medicine (U.S.)
   note: National Library of Medicine (U.S.) Retired in 2019. NLM toxicology information services have been integrated into other NLM products and services.
   link: https://www.nlm.nih.gov/toxnet
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990051486550106381':
 - collection_name: 'Research Connections: Child Care & Early Education'
   interface_name: Research Connections
   note: Research Connections.
   link: https://researchconnections.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990032594980106381':
 - collection_name: Global development finance.
   interface_name: World Bank
   note: World Bank. Access to the World Bank online version.
   link: https://openknowledge.worldbank.org/search?query=%2522Global%2520development%2520finance%2522
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990035202000106381':
 - collection_name: Performing arts periodicals database.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/iipa?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990035158790106381':
 - collection_name: Ulrich's periodicals directory.
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: http://ulrichsweb.serialssolutions.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005989580106381':
 - collection_name: 'Index-catalogue of the Library of the Surgeon-General''s Office, United States Army:'
   interface_name: NLM
   note: NLM. Access to the NLM online version.
   link: http://www.indexcat.nlm.nih.gov/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176088230106381':
 - collection_name: 'African newspapers : The British Library collection.'
   interface_name: Readex (Firm)
   note: Readex (Firm) Access to the Readex (Firm) online version restricted; authentication may be required.
   link: https://infoweb.newsbank.com/apps/readex/?p=HN-BPLAN1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121034280106381':
 - collection_name: BrillOnline dictionaries.
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://dictionaries.brillonline.com/iedo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121034230106381':
 - collection_name: Brill's Medieval reference library online.
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brillonline.com/cluster/Brill%25E2%2580%2599s%2520Medieval%2520Reference%2520Library
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052228140106381':
 - collection_name:
   interface_name: JapanKnowledge
   note: JapanKnowledge. Access to the JapanKnowledge online version restricted; authentication may be required.
   link: https://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052199260106381':
 - collection_name: Film index international
   interface_name: online
   note: online. Access to the online version restricted ; authentication may be required.
   link: http://fii.chadwyck.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161720030106381':
 - collection_name: 'KWAe : Kritische Robert Walser-Ausgabe /'
   interface_name: Kritische Robert Walser-Ausgabe
   note: Kritische Robert Walser-Ausgabe. Access to the Kritische Robert Walser-Ausgabe online version.
   link: http://kwae.kritische-walser-ausgabe.ch/kwae.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161530020106381':
 - collection_name: 'CHEMnetBASE : chemical databases online.'
   interface_name: Taylor and Francis Online
   note: Taylor and Francis Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.chemnetbase.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990126429040106381':
 - collection_name: Encyclopedia of ancient Greek language and linguistics
   interface_name: BrillOnline reference works
   note: BrillOnline reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: http://referenceworks.brillonline.com/browse/encyclopedia-of-ancient-greek-language-and-linguistics
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990126428640106381':
 - collection_name: Brill Online E-Books Latin American Anarchist And Labour Periodicals Online
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/latin-american-anarchist-periodicals
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176455130106381':
 - collection_name: Zhongguo si fa dang an shu ju ku.
   interface_name: database
   note: database. Access to the database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/47588
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176455110106381':
 - collection_name: Zhongguo di fang li shi wen xian shu ju ku /
   interface_name: database
   note: database. Access to the database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/47586
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176436830106381':
 - collection_name: VisualDx.
   interface_name: VisualDx
   note: VisualDx. Access to the VisualDx online version restricted; authentication may be required.
   link: https://www.visualdx.com/visualdx/7/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990178771220106381':
 - collection_name: South Asia open archives (SAOA).
   interface_name: JSTOR
   note: JSTOR.
   link: https://www.jstor.org/site/saoa/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990151579330106381':
 - collection_name: Social movements, elections, ephemera.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/search/simple?clear=true
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990138349020106381':
 - collection_name: AIDS.gov.
   interface_name: ''
   note: Archived site.
   link: http://purl.fdlp.gov/GPO/gpo60188
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990185273400106381':
 - collection_name: NK news.org
   interface_name: selected features
   note: selected features. ​Access to selected features restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/40738
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990059388630106381':
 - collection_name: DRAM
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: http://proxy.dramonline.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990059382600106381':
 - collection_name: SimplyAnalytics.
   interface_name: SimplyAnalytics
   note: SimplyAnalytics. 5 concurrent user limit. Some website features require a personal account. Authorized U-M users (+ guests in U-M Libraries)
   link: http://app.simplyanalytics.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040091610106381':
 - collection_name: Water resources abstracts WRA.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/waterresources?accountid=14584
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Water resources abstracts WRA.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/waterresources?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990040028560106381':
 - collection_name: Michigan ethnic directory.
   interface_name: University of Michigan
   note: University of Michigan. Access to the University of Michigan online version.
   link: http://quod.lib.umich.edu/cgi/b/bib/bib-idx?c=ethnic
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990039927500106381':
 - collection_name: ProQuest statistical insight.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://statistical.proquest.com/statisticalinsight/search/basic/sibasicsearch
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990039635080106381':
 - collection_name: Past masters philosophical texts.
   interface_name: University of Michigan Library
   note: University of Michigan Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://quod.lib.umich.edu/p/pmast/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990034821410106381':
 - collection_name: Project Muse
   interface_name: Project Muse
   note: Project Muse. Authorized U-M users (+ guests in U-M Libraries)
   link: https://muse.jhu.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990042418700106381':
 - collection_name: Digital Sanborn maps 1867-1970
   interface_name: Sanborn
   note: Sanborn. Access to the Sanborn online version restricted ; authentication may be required.
   link: http://sanborn.umi.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990035083400106381':
 - collection_name: Thomas A. Edison papers
   interface_name: Rutgers School of Arts and Sciences
   note: Rutgers School of Arts and Sciences. Open access for all users.
   link: http://edison.rutgers.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990035813380106381':
 - collection_name: International index to black periodicals IIBP full text.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://gateway.proquest.com/openurl?url_ver=Z39.88-2004&res_dat=xri:bsc:&rft_dat=xri:bsc:contents:journals
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047134690106381':
 - collection_name: 'KISS : Hanʼguk ŭi haeksim chisik chŏngbo chawŏn.'
   interface_name: Korean Studies Information
   note: Korean Studies Information. Access to the Korean Studies Information online version restricted; authentication may be required.
   link: http://kiss.kstudy.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047134450106381':
 - collection_name: Magazineplus
   interface_name: Nichigai Web
   note: Nichigai Web. 10 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://web.nichigai.jp/magazine?user_id=MIC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990047121880106381':
 - collection_name: DBpia 소개
   interface_name: Nurimedia
   note: Nurimedia. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.dbpia.co.kr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990047121840106381':
 - collection_name: CHANT (Chinese Ancient Texts) database Han da wen ku /
   interface_name: CHANT (Chinese Ancient Texts) database
   note: CHANT (Chinese Ancient Texts) database. Access to the CHANT (Chinese Ancient Texts) database restricted; authentication may be required.
   link: http://proxy.lib.umich.edu/login?url=http://proxy.lib.umich.edu/login?url=http://www.lib.umich.edu/database/link/9315
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990045996630106381':
 - collection_name: Ulrich's periodicals directory.
   interface_name: ''
   note: Access to the Ulrich's periodicals directory online version restricted; authentication may be required.
   link: http://libproxy.umflint.edu:2048/login?url=http://www.ulrichsweb.com/ulrichsweb/Search/advancedSearch.asp?navPage=1
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '990045996570106381':
 - collection_name: ProQuest newsstand
   interface_name: ''
   note: Access restricted (authentication may be required) Authorized U-M users (+ guests in U-M Libraries)
   link: http://libproxy.umflint.edu:2048/login?url=http://proquest.umi.com/login?COPT=U01EPTYmSU5UPTAmVkVSPTImREJTPUc1&clientId=16043
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043798460106381':
 - collection_name: Television news archive
   interface_name: Vanderbuilt University
   note: Vanderbuilt University. Access to the Vanderbuilt University online version .
   link: http://tvnews.vanderbilt.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990114858880106381':
 - collection_name: Maisaku Mainichi shinbun no dētabēsu.
   interface_name: ''
   note: ''
   link: http://mainichi.jp/contents/edu/maisaku/login.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990114735260106381':
 - collection_name: Artnet.com
   interface_name: Artnet
   note: Artnet. Access to the Artnet online version restricted; authentication may be required.
   link: https://www.artnet.com/price-database/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990138327440106381':
 - collection_name: 'Tectónica : arquitectura y soluciones constructivas'
   interface_name: Tectónica
   note: Tectónica. 5 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.tectonica.archi/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990169907130106381':
 - collection_name: Explore census data /
   interface_name: GPO
   note: GPO. Access to the GPO online version .
   link: https://purl.fdlp.gov/GPO/gpo120978
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990121601730106381':
 - collection_name: ProQuest statistical abstract of the U.S.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://statabs.proquest.com/sa/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990088593890106381':
 - collection_name: Shu tong wen gu ji shu ju ku
   interface_name: Shu tong wen gu ji shu ju ku
   note: Shu tong wen gu ji shu ju ku. Access to the Shu tong wen gu ji shu ju ku restricted; authentication may be required.
   link: http://guji.unihan.com.cn/permit/ipauto
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990146236310106381':
 - collection_name: UNIDO statistics data portal.
   interface_name: United Nations
   note: United Nations. Access to the United Nations online version.
   link: http://stat.unido.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990137883760106381':
 - collection_name: 'Christian Muslim relations : 1500 - 1900.'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://referenceworks.brillonline.com/browse/christian-muslim-relations-ii
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990137878380106381':
 - collection_name: 'Christian Muslim relations : 600 - 1500.'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://referenceworks.brillonline.com/browse/christian-muslim-relations-i
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052086090106381':
 - collection_name: Mergent online
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.mergentonline.com/basicsearch.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052080290106381':
 - collection_name: FRASER Federal Reserve archival system for economic research.
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.access.gpo.gov/GPO/LPS65364
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990170564970106381':
 - collection_name: 'Kinokuniya gakujutsu denshi toshokan = KinoDen : Kinokuniya digital library.'
   interface_name: Kinokuniya Digital Library
   note: Kinokuniya Digital Library. Access limited to 1 concurrent user per title; Access to the Kinokuniya Digital Library restricted; authentication may be required.
   link: https://kinoden.kinokuniya.co.jp/umichigan/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990127770240106381':
 - collection_name: Trench journals and unit magazines of the First World War
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/trenchjournals
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990141873040106381':
 - collection_name: Mark Twain Project Online authoritative texts, documents, and historical research.
   interface_name: Mark Twain Project
   note: Mark Twain Project. Access to the Mark Twain Project Online.
   link: http://www.marktwainproject.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990150008600106381':
 - collection_name: Archives of the Presbyterian Church of Cuba Online.
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/archives-of-the-presbyterian-church-of-cuba-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990141039360106381':
 - collection_name: Zi lin yang hang Zhong Ying wen bao zhi quan wen shu ju ku (1850-1951) /
   interface_name: National index to Chinese newspapers & periodicals full-text database
   note: National index to Chinese newspapers & periodicals full-text database. Access to the National index to Chinese newspapers & periodicals full-text database restricted to 5 concurrent users; authentication may be required; Scroll down to select desired title.
   link: http://www.lib.umich.edu/database/link/41111
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990163702190106381':
 - collection_name: Digital library of the Caribbean.
   interface_name: Digital library of the Caribbean
   note: Digital library of the Caribbean. Access to the Digital library of the Caribbean online version.
   link: http://www.dloc.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990133897530106381':
 - collection_name: NGA GEOnet names server (GNS).
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.access.gpo.gov/GPO/LPS18715
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990068202830106381':
 - collection_name: Europa world plus
   interface_name: ''
   note: Access to the Europa World Plus online version restricted; authentication may be required.
   link: http://www.europaworld.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990170330490106381':
 - collection_name: Kotar.
   interface_name: Kotar
   note: Kotar. Access to the Kotar online version restricted; authentication may be required.
   link: https://search.lib.umich.edu/databases/record/46954
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990140969990106381':
 - collection_name: Nearmap.
   interface_name: Nearmap
   note: Nearmap. Individual registration required for access to the Nearmap online version; authentication required.
   link: https://search.lib.umich.edu/databases/record/46878
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990079966720106381':
 - collection_name: 'State papers online : early modern government in Britain and Europe.'
   interface_name: Gale/Cengage Learning
   note: Gale/Cengage Learning. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/SPOL?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990149056920106381':
 - collection_name: PsycTHERAPY.
   interface_name: American Psychological Association
   note: American Psychological Association. Access to the American Psychological Association online version restricted; authentication may be required.
   link: https://psycnet.apa.org/PsycTHERAPY
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990111898970106381':
 - collection_name: China Monographic Series Full-text Database = Zhongguo xue shu ji kan quan wen shu ju ku.
   interface_name: China Knowledge Resource Integrated Database
   note: China Knowledge Resource Integrated Database. Access to the China Knowledge Resource Integrated Database restricted; authentication may be required.
   link: https://apps.lib.umich.edu/database/link/48667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990000797210106381':
 - collection_name: Ecology abstracts.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/ecology
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990115843000106381':
 - collection_name: Statista the leading statistics portal.
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: http://www.statista.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990125279970106381':
 - collection_name: Stalin digital archive
   interface_name: Yale University Press
   note: Yale University Press. Access to the Yale University Press online version restricted; authentication may be required.
   link: http://www.stalindigitalarchive.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990125262920106381':
 - collection_name: SAGE research methods.
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://methods.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990140483270106381':
 - collection_name: U.S. Department of Health and Human Services Office of Minority Health.
   interface_name: ''
   note: Archived site.
   link: http://purl.fdlp.gov/GPO/gpo63888
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990098969800106381':
 - collection_name: Hooked on evidence
   interface_name: ''
   note: Free access; personal registration required.
   link: http://www.hookedonevidence.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990166153740106381':
 - collection_name: News, policy & politics magazine archive.
   interface_name: Proquest
   note: Proquest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/nppma?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990166094290106381':
 - collection_name: Index Buddhicus Online.
   interface_name: BrillOnline primary sources
   note: BrillOnline primary sources. Authorized U-M users (+ guests in U-M Libraries)
   link: http://bibliographies.brillonline.com/browse/index-buddhicus-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990166091470106381':
 - collection_name: History of global Christianity online.
   interface_name: BrillOnline primary sources
   note: BrillOnline primary sources. Access to the BrillOnline primary sources online version restricted; authentication may be required.
   link: https://referenceworks.brillonline.com/browse/history-of-global-christianity-online
   status: Available
-'990058128360106381':
-- collection_name: World newspaper archive
-  interface_name: Readex
-  note: Readex. Access to the Readex online version restricted; authentication may be required.
-  link: http://infoweb.newsbank.com/?db=WHNPX
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990123356210106381':
 - collection_name: OATD -- Open access theses and dissertations.
   interface_name: ''
   note: ''
   link: http://oatd.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052238280106381':
 - collection_name: China core newspapers full-text database.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: http://oversea.cnki.net/kns55/brief/result.aspx?dbPrefix=CCND
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990155846160106381':
 - collection_name: Documenting White supremacy and its opponents in the 1920s
   interface_name: Reveal Digital
   note: Reveal Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dwso.revealdigital.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990155823050106381':
 - collection_name: TRB publications /
   interface_name: ''
   note: Access to the Transportaion Research Board.
   link: http://www.trb.org/TRB/publications/Publications.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107567000106381':
 - collection_name: Earthquake engineering abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/earthquake
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107566720106381':
 - collection_name: Civil engineering abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/civilengineering
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107566630106381':
 - collection_name: Biotechnology research abstracts
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/biotechresearch
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990182973680106381':
 - collection_name: BuddhaNexus.
   interface_name: Digital orientalist
   note: Digital orientalist. Access to the Digital orientalist online version.
   link: https://buddhanexus.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990055973910106381':
 - collection_name: OSA publishing
   interface_name: Optical Society of America
   note: Optical Society of America. Access to the Optical Society of America online version restricted; authentication may be required.
   link: https://www.osapublishing.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990042189920106381':
 - collection_name: e-EROS encyclopedia of reagents for organic synthesis.
   interface_name: Wiley
   note: Wiley. Authorized U-M users (+ guests in U-M Libraries)
   link: http://onlinelibrary.wiley.com/book/10.1002/047084289X
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041017140106381':
 - collection_name: 'GuideStar : the national database of nonprofit organizations /'
   interface_name: GuideStar
   note: GuideStar. Access to the GuideStar online version restricted; authentication may be required; Individual account required to download selected resources.
   link: https://learn.guidestar.org/news/publications/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'GuideStar : the national database of nonprofit organizations /'
   interface_name: GuideStar
   note: GuideStar. Access to the GuideStar online version restricted; authentication may be required; Individual account required to download selected resources.
   link: https://www.guidestar.org/NonprofitDirectory.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990055667540106381':
 - collection_name: Early American imprints, Series II, Shaw-Shoemaker (1801-1819)
   interface_name: Readex (Firm)
   note: Readex (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://infoweb.newsbank.com/?db=SHAW
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990070950770106381':
 - collection_name: Yomidasu rekishikan
   interface_name: ''
   note: ''
   link: https://database.yomiuri.co.jp/rekishikan/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990097486120106381':
 - collection_name: AllAfrica.com
   interface_name: AllAfrica
   note: AllAfrica. Authorized U-M users (+ guests in U-M Libraries)
   link: https://allafrica.com/search/advanced.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990182448200106381':
 - collection_name: Bibliography and index of micropaleontology.
   interface_name: Micropaleontology Press
   note: Micropaleontology Press. Access to the Micropaleontology Press online version restricted; authentication may be required.
   link: http://www.micropress.org/bim/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990174534190106381':
 - collection_name: 'Moazine : chŏnja chapchi sŏbisŭ.'
   interface_name: ''
   note: ''
   link: https://dl.moazine.com/lib/main.asp?dl=9MtJb2T3nzH3BEvu609VaY52Ca3EA1Y2EWW0
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990174519470106381':
 - collection_name: MLA directory of periodicals.
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=kah
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990166498050106381':
 - collection_name: Geschichte des globalen Christentums online.
   interface_name: BrillOnline primary sources
   note: BrillOnline primary sources. Access to the BrillOnline primary sources online version restricted; authentication may be required.
   link: https://referenceworks.brillonline.com/browse/geschichte-des-globalen-christentums-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990147288920106381':
 - collection_name: 'Kyobo Mun''go sŭk''olla : Kyobo Mun''go ka mandŭn kungnae haksul nonmun chŏnmun sait''ŭ.'
   interface_name: Kyobo Book Centre
   note: Kyobo Book Centre. Access to the Kyobo Book Centre online version restricted; authentication may be required.
   link: http://scholar.dkyobobook.co.kr/main.laf
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990141285160106381':
 - collection_name: AAMI Standards eSubscription.
   interface_name: AAMI ARRAY
   note: AAMI ARRAY. 5 concurrent user limit. Authorized U-M users (no guest access)
   link: https://array.aami.org/standards-and-publications
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990165946830106381':
 - collection_name: Nikkei terekon21 Limited = Nikkei Telecom 21 Limited.
   interface_name: Nikkei Telecom 21
   note: Nikkei Telecom 21. Access to Nikkei Telecom 21 restricted; authentication may be required.
   link: http://t21ipau.nikkei.co.jp/ipauth/auth/auth?sid=1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990135719050106381':
 - collection_name: National Technical Reports Library (NTRL)
   interface_name: NTIS
   note: NTIS. Full text reports that are not available freely online. A patron can request it, NTRL will locate the report itself and send it to them; access to the NTIS online version restricted; some authentication may be required.
   link: https://ntrl.ntis.gov/NTRL/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990053886580106381':
 - collection_name: Encyclopedia of philosophy
   interface_name: Gale Virtual Reference Library
   note: Gale Virtual Reference Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://galenet.galegroup.com/servlet/eBooks?ste=22&docNum=CX3446899999&q=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990098673950106381':
 - collection_name: African writers series
   interface_name: online
   note: online. Access to the online version restricted; authentication may be required.
   link: http://collections.chadwyck.com/home/home_aws.jsp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990069591380106381':
 - collection_name: DynaMed
   interface_name: ''
   note: Authentication may be required.
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=dynamed
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '990069579990106381':
 - collection_name: Duxiu duxiu.com
   interface_name: Duxiu
   note: Duxiu. Access to the Duxiu restricted; authentication may be required.
   link: http://www.duxiu.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990069579880106381':
 - collection_name: Material conneXion
   interface_name: ''
   note: Access via Material ConneXion restricted; authentication may be required.
   link: https://search.lib.umich.edu/databases/record/10691
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990161384810106381':
 - collection_name: CINDAS
   interface_name: CINDAS LLC
-  note: CINDAS LLC. Access to the CINDAS LLC online version restricted; authentication may be required.
+  note: CINDAS LLC. Authorized U-M users (+ guests in U-M Libraries)
   link: https://cindasdata.com/Applications?
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056200560106381':
-- collection_name: Bookshelf
-  interface_name: online
-  note: online. Access to the online version.
-  link: http://purl.access.gpo.gov/GPO/LPS86584
+- collection_name: National Center for Biotechnology Information Bookshelf
+  interface_name: National Center for Biotechnology Information
+  note: National Center for Biotechnology Information. Open access for all users.
+  link: https://purl.access.gpo.gov/GPO/LPS86584
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056172250106381':
 - collection_name: PTSDpubs
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/pilots?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056167910106381':
 - collection_name: BUDA - The Buddhist Digital Archives
   interface_name: BUDA - Buddhist Digital Archives
   note: BUDA - Buddhist Digital Archives. Authorized U-M users (+ guests in U-M Libraries)
   link: https://library.bdrc.io/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056473240106381':
 - collection_name: Archive of Celtic-Latin literature (ACLL).
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://clt.brepolis.net/acll/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990039872100106381':
 - collection_name: ERIC
   interface_name: FirstSearch ERIC search page
   note: FirstSearch ERIC search page. Access to FirstSearch ERIC search page restricted; authentication may be required.
   link: http://firstsearch.oclc.org/dbname=ERIC;FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: ERIC
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/eric
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990039827120106381':
 - collection_name: Philosopher's index
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/philosophersindex/accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990051187980106381':
 - collection_name: Periodicals archive online
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/pao
   status: Available
-'990117394390106381':
-- collection_name: OntheBoards. TV
-  interface_name: online
-  note: online. Access to the online version restricted; authentication may be required.
-  link: http://www.ontheboards.tv
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005055590106381':
 - collection_name: Pollution abstracts.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/pollution
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990039351950106381':
 - collection_name: The Internet movie database
   interface_name: IMDB
   note: IMDB. Access to the IMDB online version.
   link: http://us.imdb.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990069617020106381':
 - collection_name: 'Zasshi kiji sakuin shūsei dētabēsu : Meiji kara genzai made sōgō zasshi kara chishi made = The complete database for Japanese magazines and periodicals from the Meiji era to the present.'
   interface_name: ''
   note: ''
   link: http://zassaku-plus.com/
   status: Available
-'990159330650106381':
-- collection_name: Prize papers online.
-  interface_name: BrillOnline primary sources
-  note: BrillOnline primary sources. Access to the BrillOnline primary sources online version restricted; authentication may be required.
-  link: http://primarysources.brillonline.com/browse/prize-papers-part-3-online
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990159330500106381':
-- collection_name: Sacramentum mundi online /
+- collection_name: Sacramentum mundi online
   interface_name: BrillOnline reference works
-  note: BrillOnline reference works. Access to the BrillOnline reference works online version restricted; authentication may be required.
+  note: BrillOnline reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: http://referenceworks.brillonline.com/browse/sacramentum-mundi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990159330470106381':
 - collection_name: 'Brockelmann in English : the history of the Arabic written tradition online.'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/breo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990128399010106381':
 - collection_name: TAIR the Arabidopsis information resource.
   interface_name: TAIR
   note: TAIR. Access to TAIR restricted; authentication may be required.
   link: http://arabidopsis.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990133749080106381':
 - collection_name: LawInfoChina
   interface_name: ''
   note: Access restricted; authentication may be required.
   link: http://www.lawinfochina.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990133637230106381':
 - collection_name: Bibliographie de civilisation médiévale
   interface_name: ''
   note: Access restricted; authentication may be required.
   link: http://apps.brepolis.net/bmb/search.cfm?
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990133636750106381':
 - collection_name: Perseus digital library
   interface_name: Perseus
   note: Perseus. Access to the Perseus online version.
   link: http://www.perseus.tufts.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990128901070106381':
 - collection_name: ProQuest statistical abstracts of the world.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://statabs.proquest.com/international/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990092482830106381':
 - collection_name: HealthCare.gov
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.fdlp.gov/GPO/gpo906
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990120981060106381':
 - collection_name: Shen bao /
   interface_name: Shen bao quan wen shu ju ku
   note: Shen bao quan wen shu ju ku. Select "Modern Documents" and "Login" button. Authorized U-M users (+ guests in U-M Libraries)
   link: https://apps.lib.umich.edu/database/link/30509
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990100423640106381':
 - collection_name: AgEcon search
   interface_name: ''
   note: ''
   link: http://ageconsearch.umn.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990100183770106381':
 - collection_name: Corpus de la première littérature francophone d'Afrique noire, écrite et orale, des origines aux indépendances (fin 18e siècle-1960)
   interface_name: ''
   note: ''
   link: http://www.classiques-garnier.com/numerique-bases/index.php?module=App&action=FrameMain&colname=ColClf
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990095423930106381':
 - collection_name: Brockelmann online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/broo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990136784640106381':
 - collection_name: Sage stats
   interface_name: Sage
   note: Sage. Access to the Sage online version restricted; authentication may be required.
   link: http://data.sagepub.com/sagestats/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990053899090106381':
 - collection_name: Images from medieval and Renaissance manuscripts
   interface_name: Princeton University Pierpont Morgan Library
   note: Princeton University Pierpont Morgan Library. Access to the Princeton University Pierpont Morgan Library online version.
   link: http://corsair.morganlibrary.org/ICAIntro/ICAintroshortdesc.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990134430790106381':
 - collection_name: Economist Intelligence Unit country reports archive.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/eiuarchive/index
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990134416910106381':
 - collection_name: Wan Qing qi kan quan wen shu ju ku (1833-1911).
   interface_name: National index to Chinese newspapers and periodicals
   note: National index to Chinese newspapers and periodicals. Access limited to 5 concurrent user; Access to the National index to Chinese newspapers and periodicals online version restricted; Search for content; authentication may be required.
   link: http://www.lib.umich.edu/database/link/34793
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990055809260106381':
 - collection_name: Anatomy.tv. the world's most detailed 3D model of human anatomy online.
   interface_name: STAT!Ref
   note: STAT!Ref. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.anatomy.tv/titles
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990058369500106381':
 - collection_name: The HistoryMakers.
   interface_name: HistoryMakers
   note: HistoryMakers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://da.thehistorymakers.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990058360730106381':
 - collection_name: LALT Leiden Armenian lexical textbase /
   interface_name: LALT
   note: LALT. Access to the LALT online version.
   link: http://www.sd-editions.com/LALT/access.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056072000106381':
 - collection_name: World Digital Library
   interface_name: US GPO
   note: US GPO. Access to the US GPO online version.
   link: http://purl.access.gpo.gov/GPO/LPS86109
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041798200106381':
 - collection_name: ISI emerging markets /
   interface_name: ''
   note: Access restricted (authentication may be required)
   link: http://site.securities.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041772500106381':
 - collection_name: Projekt DYABOLA.
   interface_name: Biering & Brinkmann
   note: Biering & Brinkmann. Click on "Activate IP access" check-box. Select "Start." Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.dyabola.de/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990041732520106381':
 - collection_name: Wright American fiction, 1851-1875
   interface_name: University of Indiana
   note: University of Indiana. Access to the University of Indiana online version.
   link: http://www.letrs.indiana.edu/web/w/wright2/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990000630430106381':
 - collection_name: Index-catalogue of the Library of the Surgeon-General's Office, United States Army.
   interface_name: NLM
   note: NLM. Access to the NLM online version.
   link: http://www.indexcat.nlm.nih.gov/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043266360106381':
 - collection_name: Early American imprints, Series I, Evans (1639-1800)
   interface_name: Readex
   note: Readex. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infoweb.newsbank.com/?db=EVAN&s%255Fstart=evans
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043265720106381':
 - collection_name: American Indian history online
   interface_name: Infobase
   note: Infobase. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.fofweb.com/Direct2.asp?ID=16234&ItemID=WE43
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990042906160106381':
 - collection_name: Geographic Names Information System
   interface_name: GNIS
   note: GNIS. Access to the GNIS online version.
   link: http://geonames.usgs.gov/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990039264660106381':
 - collection_name: Handbooks in economics.
   interface_name: ScienceDirect
   note: ScienceDirect. Access to the ScienceDirect online version restricted; authentication may be required.
   link: http://www.sciencedirect.com/science/handbooks/sub/economics/all/full-text-access
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990050721690106381':
 - collection_name: iPOLL /
   interface_name: Roper Center for Public Opinion Research
   note: Roper Center for Public Opinion Research. Access to the Roper Center for Public Opinion Research online version restricted ; authentication may be required.
   link: https://ropercenter.cornell.edu/CFIDE/cf/action/ipoll/index.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990163445020106381':
 - collection_name: Wards Intelligence.
   interface_name: Ward'sAuto
   note: Ward'sAuto. Access to the Ward's Intelligence online version restricted; authentication may be required.
   link: http://subscribers.wardsintelligence.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990159552960106381':
 - collection_name: 'Online Egyptological Bibliography : OEB.'
   interface_name: Online Egyptological Bibliography
   note: Online Egyptological Bibliography. Access to the Online Egyptological Bibliography restricted; authentication may be required.
   link: http://oeb.griffith.ox.ac.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990159906340106381':
 - collection_name: Latin American Public Opinion Project (LAPOP), 2004-2015 [28 COUNTRIES]
   interface_name: ''
   note: Access restricted ; authentication may be required.
   link: http://doi.org/10.3886/ICPSR36562.v1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990143226390106381':
 - collection_name: 'Musical Theater Songs : The Song is You.'
-  interface_name: ''
-  note: ''
+  interface_name: MusicalTheaterSongs.com
+  note: MusicalTheaterSongs.com. Authorized U-M users (+ guests in U-M Libraries)
   link: https://musicaltheatersongs.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990165009740106381':
 - collection_name: Fire insurance maps online.
   interface_name: Fire Insurance Maps
   note: Fire Insurance Maps. Access to the Fire Insurance Maps Online Library Edition restricted; authentication may be required.
   link: https://fims.historicalinfo.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990068227680106381':
 - collection_name: The Global library of women's medicine
   interface_name: GLOWM
   note: GLOWM. Access to the GLOWM online version.
   link: http://www.glowm.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: The Global library of women's medicine
   interface_name: SAGE
   note: SAGE. Access to the SAGE online version restricted; authentication may be required.
   link: http://dx.doi.org/10.4135/9781412963916
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990068222330106381':
 - collection_name: Embase.
   interface_name: Elsevier
   note: Elsevier. Access to the Elsevier online version restricted; authentication may be required.
   link: https://www.embase.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990129562570106381':
 - collection_name: Sovetskai͡a kulʹtura digital archive.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: http://dlib.eastview.com/browse/udb/1790
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990163172430106381':
 - collection_name: BBC monitoring.
   interface_name: BBC
   note: BBC. Access to the BBC online version restricted; authentication may be required.
   link: https://monitoring.bbc.co.uk/api/login/sso?entityId=https://shibboleth.umich.edu/idp/shibboleth
   status: Available
-'990056671000106381':
-- collection_name: Chronicling America historic American newspapers.
-  interface_name: ''
-  note: ''
-  link: http://bibpurl.oclc.org/web/19370
-  status: Available
-- collection_name: Chronicling America historic American newspapers.
-  interface_name: Library of Congress
-  note: Library of Congress. Access to the Library of Congress online version.
-  link: http://www.loc.gov/chroniclingamerica/
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056663670106381':
 - collection_name: Computer database
   interface_name: ''
   note: InfoTrac Web version ; Access restricted ; authentication may be required.
   link: http://libproxy.umflint.edu:2048/login?url=http://find.galegroup.com/itx/start.do?prodId=CDB&userGroupName=lom_umichflint
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990154694590106381':
 - collection_name: Ancient Near East monographs = Monografías sobre el Antiguo Cercano Oriente.
   interface_name: Society of Biblical Literature
   note: Society of Biblical Literature. Access to the Society of Biblical Literature online version.
   link: https://www.sbl-site.org/publications/books_anemonographs.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990164893180106381':
 - collection_name: Percussion orchestrations.
   interface_name: Percussion Orchestrations
   note: Percussion Orchestrations. Access to the Percussion Orchestrations online version restricted; authentication may be required.
   link: http://www.percorch.com/composers?letter=A
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990130216690106381':
 - collection_name: CANSIM @ CHASS.
   interface_name: University of Toronto, CHASS
   note: University of Toronto, CHASS. Authorized U-M users (+ guests in U-M Libraries)
   link: http://dc.chass.utoronto.ca/chasscansim/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990138712910106381':
 - collection_name: Hathi Trust digital library.
   interface_name: HathiTrust
   note: HathiTrust. Access to the HathiTrust online version.
   link: https://www.hathitrust.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990134873780106381':
 - collection_name: Caribbean newspaper digital library
   interface_name: University of Florida Digital Collections
   note: University of Florida Digital Collections. Access to the University of Florida Digital Collections online version.
   link: http://dloc.com/cndl
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990117085670106381':
 - collection_name: U.S. imports of merchandise
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.fdlp.gov/GPO/gpo25059
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990000744300106381':
 - collection_name: Risk abstracts.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/riskabstracts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990000733520106381':
 - collection_name: 'Linguistics and language behavior abstracts : LLBA.'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/llba/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990034458880106381':
 - collection_name: Local climatological data
   interface_name: NOAA
   note: NOAA. Access to the NOAA online version restricted; authentication may be required.
   link: http://www.ncdc.noaa.gov/IPS/lcd/lcd.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005031550106381':
 - collection_name: Patrologia orientalis.
   interface_name: Brepolis
   note: Brepolis. Authorized U-M users (+ guests in U-M Libraries)
   link: http://clt.brepolis.net/pod/pages/Search.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990042734570106381':
 - collection_name: The international movie industry
   interface_name: EBSCO eBook collection
   note: EBSCO eBook collection. Access limited to 1 concurrent user; Access to the EBSCO eBook collection online version restricted; authentication may be required.
   link: http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=45744
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990029868870106381':
 - collection_name: AMA FREIDA fellowship and residency electronic interactive database access system.
   interface_name: ''
   note: Acess to the AMA online version.
   link: https://freida.ama-assn.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990145148490106381':
 - collection_name: 'CumInCAD : cumulative index of computer aided architectural design.'
   interface_name: online
   note: online. Access to the online version.
   link: http://papers.cumincad.org/cgi-bin/works/BrowseTree?field=series&order=AZ
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990126289810106381':
 - collection_name: 'Congress.gov : United States legislative information.'
   interface_name: GPO
   note: GPO. Access to the GPO online version.
   link: http://purl.fdlp.gov/GPO/gpo41670
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990126289400106381':
 - collection_name: International historical statistics, 1750-2010
   interface_name: SpringerLink
   note: SpringerLink. Authorized U-M users (+ guests in U-M Libraries)
   link: http://dx.doi.org/10.1057/9781137305688
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990058684180106381':
 - collection_name: Public administration abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=21h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107580030106381':
 - collection_name: Toxicology abstracts
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/toxicologyabstracts?accountid=14584
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Toxicology abstracts
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/toxicologyabstracts?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107578000106381':
 - collection_name: Microbiology abstracts.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/microbiologya?accountid=14584
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Microbiology abstracts.
   interface_name: ProQuest (Firm)
   note: ProQuest (Firm) Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/microbiologya?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107578410106381':
 - collection_name: Solid state and superconductivity abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/solidstateabstracts?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990107578210106381':
 - collection_name: Social services abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/socialservices?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990150309790106381':
 - collection_name: LawnB = Lo aen bi.
   interface_name: ''
   note: Full text available via LAWnB (access restricted; authentication may be required)
   link: http://www.lib.umich.edu/database/link/42971
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990150309740106381':
 - collection_name: KoreaA2Z.
   interface_name: ''
   note: Full text available via Dongbang Media (access restricted; authentication may be required)
   link: http://www.lib.umich.edu/database/link/42957
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990150309710106381':
 - collection_name: Tijit'ŏl yesul munhwa kangjwa = The digital culture art course.
   interface_name: ''
   note: Full text available via Dongbang Media (access restricted; authentication may be required)
   link: https://www.lib.umich.edu/database/link/42961
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990150309700106381':
 - collection_name: Chininjin yŏksa munhwa sirijŭ /
   interface_name: ''
   note: Full text available via Zininzin (access restricted; authentication may be required)
   link: http://www.lib.umich.edu/database/link/42955%E2%80%8B
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990150309690106381':
 - collection_name: Han'guk yŏksa munhwa chosa charyo deit'ŏbeisŭ = Korean history & culture research database.
   interface_name: ''
   note: Full text available via Zininzin (access restricted; authentication may be required)
   link: http://www.lib.umich.edu/database/link/42953
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990124334890106381':
 - collection_name: BrowZine.
   interface_name: University of Michigan Library
   note: University of Michigan Library. Access to the University of Michigan Library online version restricted; authentication may be required.
   link: https://search.lib.umich.edu/databases/record/40117
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990160467750106381':
 - collection_name: Ren min ri bao tu wen shu ju ku.
   interface_name: database
   note: database. Access to the database restricted; authentication may be required.
   link: https://www.oriprobe.com/peoplesdaily.shtml
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990067810560106381':
 - collection_name: Going global
   interface_name: ''
   note: Related free website.
   link: http://www.goinglobal.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Going global
   interface_name: ''
   note: Access restricted; authentication may be required.
   link: http://online.goinglobal.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990067776770106381':
 - collection_name: Winmo
   interface_name: Winmo
   note: Winmo. Access to the Winmo online version restricted; authentication may be required.
   link: https://launch.winmo.com/login/university?key=VxL7FxrzSFA43OtSID7A&name=Michigan%2520University
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990142475770106381':
 - collection_name: Openedition revues.org, calenda, hypotheses.org.
   interface_name: OpenEdition
   note: OpenEdition. Access to the OpenEdition online version restricated; authentication may be required.
   link: http://www.openedition.org/?lang=en
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041668940106381':
 - collection_name: Pew Internet & American life project an initiative of the Pew Research Center, a project of the Tides Center, and fully funded by the Pew Charitable Trusts.
   interface_name: Pew Research Center
   note: Pew Research Center. Access to the Pew Research Center online version.
   link: http://www.pewinternet.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041668860106381':
 - collection_name: Advisory Board.
   interface_name: ''
   note: ''
   link: https://www.advisory.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990041656040106381':
 - collection_name: Data Axle Reference Solutions /
   interface_name: ''
   note: Access to the Data Axle online version restricted; authentication may be required.
   link: http://www.referenceusa.com/Home/Home
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049586550106381':
 - collection_name: Wen yuan ge Si ku quan shu nei lian wang ban.
   interface_name: East View Information Services
   note: East View Information Services. Access limited to 1 concurrent user; Institutional password required for access to the Siku Quanshu database; Client program software must be installed on a personal computer OR use a public terminal in the Asia Library Reference Room, 4th Floor Graduate Library North.
   link: https://apps.lib.umich.edu/pk/resource.php?004958655
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990113877370106381':
 - collection_name: Child development and adolescent studies
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fgh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990113876870106381':
 - collection_name: Arctic & Antarctic regions
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fih
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990005458940106381':
 - collection_name: International index to film periodicals.
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://fiaf.chadwyck.com/search/initIndexSearch.do
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052170480106381':
 - collection_name: Photographic portraits of American artists from the Peter A. Juley & Son Collection
   interface_name: Smithsonian
   note: Smithsonian. Access to the Smithsonian online version.
   link: http://sirismm.si.edu/siris/julquickstart.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990074273100106381':
 - collection_name: 'ASTM compass : your portal for standards, testing, learning, & more.'
   interface_name: ASTM Compass
   note: ASTM Compass. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.astm.org/astm-compass
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990096475500106381':
 - collection_name: CQ Press library.
   interface_name: CQ Press
   note: CQ Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://cqpress.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990174978070106381':
 - collection_name: 'MIRS : Michigan''s independent source of news & information'
   interface_name: MIRS
   note: MIRS. Authorized U-M users (+ guests in U-M Libraries)
   link: https://mirs.news/news
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990155355200106381':
 - collection_name: Chinese text project /
   interface_name: Chinese text project
   note: Chinese text project. Access to Chinese text project restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/43901
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Chinese text project /
   interface_name: Chinese text project
   note: Chinese text project. Access to Chinese text project restricted; authentication may be required.
   link: http://ctext.org/zh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Chinese text project /
   interface_name: Chinese text project
   note: Chinese text project. Access to Chinese text project restricted; authentication may be required.
   link: http://ctext.org/zhs
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990155376990106381':
 - collection_name: Dialnet Plus.
   interface_name: Fundación Dialnet
   note: Fundación Dialnet. Access to the Fundación Dialnet online version.
   link: https://dialnet.unirioja.es/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990129036760106381':
 - collection_name: Met Opera on demand.
   interface_name: Metropolitan Opera
-  note: Metropolitan Opera. Metropolitan Opera access restricted; authentication may be required.
+  note: Metropolitan Opera. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ondemand.metopera.org/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990056036530106381':
 - collection_name: MyHeritage library edition.
   interface_name: EBSCO
   note: EBSCO. Access to the EBSCO online version restricted; authentication may be required.
   link: https://search.ebscohost.com/Community.aspx?site=mhlibed&return=y&groupid=main&authtype=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056023730106381':
 - collection_name: Mideastwire.com
   interface_name: ''
   note: Access restricted; authentication may be required.
   link: http://www.mideastwire.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990056015330106381':
 - collection_name: IPA Source
   interface_name: IPA
   note: IPA. Access to the IPA online version restricted (authentication may be required)
   link: http://www.ipasource.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990176060520106381':
 - collection_name: Agency for Healthcare Research and Quality.
   interface_name: ''
   note: Collection page seed list.
   link: https://purl.fdlp.gov/GPO/gpo127691
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Agency for Healthcare Research and Quality.
   interface_name: ''
   note: Home page by archived dates.
   link: https://purl.fdlp.gov/GPO/gpo127692
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990154366410106381':
 - collection_name: InnovationQ plus /
   interface_name: IEEE
   note: IEEE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://iq.ip.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990125232230106381':
 - collection_name: Music & performing arts.
   interface_name: Alexander Street Press
   note: Alexander Street Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/music-performing-arts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990052302540106381':
 - collection_name: Gu jin tu shu ji cheng
   interface_name: Complete classics collection of Ancient China database
   note: Complete classics collection of Ancient China database. Access to the Complete classics collection of Ancient China database restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/9313
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990006793170106381':
 - collection_name: Index to current urban documents.
   interface_name: ICUD
   note: ICUD. Access to the ICUD online search site restricted; authentication may be required.
   link: http://www.urbdocs.com/icud.jsp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990116957710106381':
 - collection_name: Compact memory Internetarchiv jüdischer Periodika.
   interface_name: ''
   note: ''
   link: http://www.compactmemory.de/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990116950690106381':
 - collection_name: Engineering village
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.engineeringvillage.com/home.url
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990021834390106381':
 - collection_name: Inter-university Consortium for Political and Social Research
   interface_name: ICPSR
   note: ICPSR. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.icpsr.umich.edu/web/pages/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049362040106381':
 - collection_name: Gale virtual reference library
   interface_name: Gale Virtual Reference Library
   note: Gale Virtual Reference Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infotrac.galegroup.com/itweb/umuser?db=GVRL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252544706381':
 - collection_name: Music Periodicals Database
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/iimp
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252545206381':
 - collection_name: HeinOnline World Constitutions Illustrated
   interface_name: Hein Online
   note: Hein Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://heinonline.org/HOL/Index?collection=cow
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252545806381':
 - collection_name: 'Gale OneFile: News'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/stnd?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252546106381':
 - collection_name: Gale Literature Resource Center
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/litrc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252546406381':
 - collection_name: Periodicals of Central Asia and the Caucasus (UDB-CAC)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/1990
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252547006381':
 - collection_name: 'Gale OneFile: Computer Science'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/cdb?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252547306381':
 - collection_name: EBSCOhost APA PsycARTICLES
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=pdhjnh,pdh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252547506381':
 - collection_name: Factiva - Classic
   interface_name: Factiva - Classic
   note: Factiva - Classic. Authorized U-M users (+ guests in U-M Libraries)
   link: https://global.factiva.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252547606381':
 - collection_name: Gale General OneFile
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/itof?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252547706381':
 - collection_name: 'Gale OneFile: Business'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/itbc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252547806381':
 - collection_name: 'Gale OneFile: Health and Medicine'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/hrca?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252548006381':
 - collection_name: Russian Governmental Publications (UDB-GOV)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/5
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252548206381':
 - collection_name: 'Gale OneFile: LegalTrac'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/lt?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252548406381':
 - collection_name: EBSCOhost International Bibliography of Theatre & Dance with Full Text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ibh
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252548606381':
 - collection_name: Gale Health and Wellness
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=HWRC&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252548706381':
 - collection_name: 'Gale In Context: Biography'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/bic?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252548806381':
 - collection_name: East View Russian Social Sciences and Humanities Periodicals (UDB-EDU)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/4
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252548906381':
 - collection_name: East View Russian Central Newspapers (UDB-COM)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252549006381':
 - collection_name: East View Russia Regional Newspapers (UDB-REG)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252549206381':
 - collection_name: Columbia International Affairs Online (CIAO)
   interface_name: Columbia International Affairs Online
   note: Columbia International Affairs Online. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.ciaonet.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252549506381':
 - collection_name: EBSCOhost Communication & Mass Media Complete
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ufh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252549806381':
 - collection_name: EBSCOhost Alt HealthWatch
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ebscohost.com/academic/alt-healthwatch
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550106381':
 - collection_name: 'Gale OneFile: Informe Academico'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ifme?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252513506381':
 - collection_name: 'ProQuest Historical Newspapers: The Christian Science Monitor'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpchristiansciencemonitor/news
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252513706381':
 - collection_name: 'ProQuest Historical Newspapers: The Baltimore Afro-American (1893-1988)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/bsc/publication/45589
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252516706381':
 - collection_name: Global Newsstream
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/globalnews
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252532506381':
 - collection_name: 'ProQuest Historical Newspapers: Times of India'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnptimesofindia
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252533006381':
 - collection_name: 'SAGE Research Methods Video: Practical Research and Academic Skills'
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://methods.sagepub.com/Search/Results?products=[15]&contentTypes=Videos
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252533206381':
 - collection_name: SAGE research methods
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: http://methods.sagepub.com/Search/Results
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252533306381':
 - collection_name: SAGE Research Methods Datasets Part I
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://methods.sagepub.com/datasets
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043432030106381':
 - collection_name: Digital National Security Archive (DNSA)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252534206381':
 - collection_name: 'Entertainment Industry Magazine Archive: Cinema, Film and Television (Part 1)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/eima2/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252534306381':
 - collection_name: 'Entertainment Industry Magazine Archive: Music, Radio and The Stage'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/eima1/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252534406381':
 - collection_name: Earth, Atmospheric & Aquatic Science Collection
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/earthatmosphericaquatic
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252534506381':
 - collection_name: American West
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.americanwest.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252535006381':
 - collection_name: 'ProQuest Historical Newspapers: Chinese Newspapers Collection'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/hnpchinesecollection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252535406381':
 - collection_name: Agricultural & Environmental Science Collection
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/agricenvironm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252537206381':
 - collection_name: EBSCOhost Applied Science & Technology Full Text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=asf
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252537506381':
 - collection_name: EBSCOhost CINAHL Complete
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ebscohost.com/nursing/products/cinahl-databases/cinahl-complete
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252538206381':
 - collection_name: EBSCOhost Applied Science & Technology Source
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=aci
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252538306381':
 - collection_name: EBSCOhost African American Historical Serials
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=h7i
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252538406381':
 - collection_name: Legal Information Source
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=lirc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252539306381':
 - collection_name: EBSCOhost Reader's Guide Full Text Mega
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rgm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252539706381':
 - collection_name: Gale 19th Century US Newspapers
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ncnp?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252539806381':
 - collection_name: Gale Economist Historical Archive, 1843-2020
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ECON?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252540506381':
 - collection_name: ABI/INFORM Dateline
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/abicomplete?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252541006381':
 - collection_name: 'ProQuest Historical Newspapers: American Hebrew Jewish Messenger'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpamericanhebrew?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252541106381':
 - collection_name: 'ProQuest Historical Newspapers: Jewish Advocate'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpjewishadvocate
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252541206381':
 - collection_name: EBSCOhost Political Science Complete
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip%252Cuid&profile=ehost&defaultdb=poh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252541606381':
 - collection_name: Advanced Technologies & Aerospace Database
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/aerospace
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252541906381':
 - collection_name: EBSCOhost Dentistry & Oral Sciences Source
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ddh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252542206381':
 - collection_name: ABI/INFORM Trade & Industry
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/abicomplete
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252542306381':
 - collection_name: ABI/INFORM Global
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/abicomplete?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252542706381':
 - collection_name: British Periodicals Collection I
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/britishperiodicals
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252542806381':
 - collection_name: British Periodicals Collection II
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/britishperiodicals
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252543106381':
 - collection_name: EBSCOhost Historical Abstracts with Full Text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ebscohost.com/academic/historical-abstracts-with-full-text
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252543206381':
 - collection_name: Seventeenth and Eighteenth Century Burney Newspapers Collection
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BBCN?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252543406381':
 - collection_name: EBSCOhost Biological and Agricultural Index Plus
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=bai
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252543506381':
 - collection_name: EBSCOhost America History and Life with Full Text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=31h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252543606381':
 - collection_name: 'British Library Newspapers, Part II: 1800-1900'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BNCN?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252544006381':
 - collection_name: Alt-PressWatch
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/altpresswatch?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252544306381':
 - collection_name: EBSCOhost Health Policy Reference Center
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=herjnh,her
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252544406381':
 - collection_name: EBSCOhost GreenFile
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=8gh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252478306381':
 - collection_name: Brillonline Ebooks Companions To Classical Studies Online Iv
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/package/9789004360280
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252478806381':
 - collection_name: Brillonline Ebooks Companions To Classical Studies Online I
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/package/9789004219274
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252484806381':
 - collection_name: NBER Working papers
   interface_name: National Bureau of Economic Research
   note: National Bureau of Economic Research. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.nber.org/papers
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252484906381':
 - collection_name: 'Gender: Identity and Social Change'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.genderidentityandsocialchange.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488106381':
 - collection_name: Psychological Experiments Online (Text)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/pexp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488206381':
 - collection_name: Psychological Experiments Online (Video) - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/psychological-experiments-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488306381':
 - collection_name: Black Short Fiction and Folklore
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://lit.alexanderstreet.com/blfi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488506381':
 - collection_name: 'Latino Literature: Poetry, Drama, and Fiction'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/litcollectionlali?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488706381':
 - collection_name: Nineteenth-Century Fiction
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/c19f
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488806381':
 - collection_name: English Poetry, Second Edition
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ep2?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252488906381':
 - collection_name: Twentieth-Century American Poetry
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/litcollection20ampous
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252489106381':
 - collection_name: Twentieth-Century African American Poetry
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/litcollection20aapus
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252489206381':
 - collection_name: Meet the Press
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/meet-the-press
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252489506381':
 - collection_name: 'Independent World Cinema: Classic and Contemporary Film - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/independent-world-cinema-classic-and-contemporary-film
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490006381':
 - collection_name: World History in Video - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/world-history-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490106381':
 - collection_name: Research Library
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/pqrl
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490306381':
 - collection_name: Ethnographic Video Online, Volume 1 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/ethnographic-video-online-foundational-films
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490406381':
 - collection_name: Ethnographic Video Online, Volume 2 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/ethnographic-video-online-foundational-films
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490506381':
 - collection_name: 'Music Online: Jazz Music Library - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/jazz
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490606381':
 - collection_name: Filmakers Library Online, Volume 4 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/filmakers-library-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490706381':
 - collection_name: 'Sixties: Primary Documents and Personal Narratives 1960-1974 (Text)'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/sixt
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490806381':
 - collection_name: Silent Film Online - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/silent-film-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252490906381':
 - collection_name: 'Music Online: Smithsonian Global Sound for Libraries, Volume 1'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/glmu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491006381':
 - collection_name: Food Studies Online (Video) - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/food-studies-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491106381':
 - collection_name: 'Dance Online: Dance in Video, Volume 1'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/dance-online-dance-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491206381':
 - collection_name: Current Affairs in Video - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/current-affairs-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491306381':
 - collection_name: 'Dance Online: Dance in Video, Volume 2 - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/dance-online-dance-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491406381':
 - collection_name: Ethnographic Video Online, Volume 3 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/ethnographic-video-online-indigenous-voices
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491506381':
 - collection_name: 'Fashion Studies Online: The Videofashion Library'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/fashion-studies-online-the-videofashion-library
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491606381':
 - collection_name: Filmakers Library Online, Volume 1 - North America
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/filmakers-library-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491706381':
 - collection_name: Filmakers Library Online, Volume 2 - North America
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/filmakers-library-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252491906381':
 - collection_name: Anthropology Online
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/anto
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492006381':
 - collection_name: March of Time
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/the-march-of-time
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492106381':
 - collection_name: Art and Architecture in Video - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/art-and-architecture-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492206381':
 - collection_name: 'Music Online: American Music - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/amso
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252492306381':
 - collection_name: Engineering Case Studies Online (Text)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/engv
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492406381':
 - collection_name: Human Rights Studies Online (Video) - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/human-rights-studies-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492506381':
 - collection_name: '60 Minutes: 1997-2014'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/60-minutes-1997-2014
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492606381':
 - collection_name: Dental Education in Video
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/dental-education-in-video-1b
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492706381':
 - collection_name: Digital Library of Classic Protestant Texts
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/tcpt
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492806381':
 - collection_name: LGBT Studies in Video, Volume 1 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/lgbt-studies-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252492906381':
 - collection_name: American History in Video - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/american-history-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493006381':
 - collection_name: 'World Newsreels Online: 1929-1966'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/world-newsreels-online-1929-1966
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493106381':
 - collection_name: Engineering Case Studies Online (Video) - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/engineering-case-studies-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493206381':
 - collection_name: 'New World Cinema: Independent Features & Shorts, 1990-Present - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/new-world-cinema-independent-features-and-shorts-1990-present
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493306381':
 - collection_name: North American Indian Thought and Culture
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/ibio
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493406381':
 - collection_name: 'North American Indian Drama: Second Edition'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ind2.alexanderstreet.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493506381':
 - collection_name: 'Music Online: Classical Music Library - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/clmu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493606381':
 - collection_name: 'Music Online: Opera in Video, Volume 1'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/music-online-opera-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252493706381':
 - collection_name: 'Music Online: The Garland Encyclopedia of World Music'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/glnd
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494106381':
 - collection_name: 'Counseling and Therapy in Video: Volume 5'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/counseling-and-therapy-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494206381':
 - collection_name: 'Harper''s Weekly: 1857-1912'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://content.harpweek.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494306381':
 - collection_name: Theatre in Context Collection (Text)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/ticc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494606381':
 - collection_name: Kafkas Werke
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/kafka
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494706381':
 - collection_name: 'Counseling and Therapy in Video: Volume 1'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/counseling-and-therapy-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494806381':
 - collection_name: 'Counseling and Therapy in Video: Volume 3'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/counseling-and-therapy-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252494906381':
 - collection_name: 'Counseling and Therapy in Video: Volume 2'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/counseling-and-therapy-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495006381':
 - collection_name: 'Counseling and Therapy in Video: Volume 4 (Text)'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/ctv4
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495106381':
 - collection_name: 'Counseling and Therapy in Video: Volume 4 (Video) - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/counseling-and-therapy-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495206381':
 - collection_name: Asian Film Online, Volume 1 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/asian-film-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495306381':
 - collection_name: 'Music Online: Classical Music in Video, Volume 1'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/music-online-classical-music-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495406381':
 - collection_name: 'Audio Drama: The L.A. Theatre Works Collection'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/radr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495606381':
 - collection_name: American Poetry
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ap
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495806381':
 - collection_name: Early American Fiction 1789-1875
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/eaf2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252495906381':
 - collection_name: Eighteenth-Century Fiction
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/c18f
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496006381':
 - collection_name: Theatre in Video, Volume 1 - North America (Pre-June 2011 Purchasers Only)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/theatre-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496106381':
 - collection_name: 'Academic Video Online: Premium - United States'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/academic-video-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496206381':
 - collection_name: Theatre in Video, Supplement
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/theatre-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496306381':
 - collection_name: Twentieth Century Advice Literature
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/adli
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496406381':
 - collection_name: Theatre in Video, Volume 2 - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/theatre-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496506381':
 - collection_name: Digital Library of the Catholic Reformation
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/dlcr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496606381':
 - collection_name: Black Thought and Culture
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/bltc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496706381':
 - collection_name: Black Studies in Video - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/black-studies-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496806381':
 - collection_name: 'Underground and Independent Comics, Comix, and Graphic Novels: Volume 2'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/comx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252496906381':
 - collection_name: 'Underground and Independent Comics, Comix, and Graphic Novels: Volume 1'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/comx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252497006381':
 - collection_name: Women and Social Movements, International
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/wasi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252497106381':
 - collection_name: Women and Social Movements in the United States, 1600-2000
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/wass
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252497306381':
 - collection_name: 'Black Drama: First Edition'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/bldr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252497406381':
 - collection_name: 'Black Drama: Second Edition'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/bld2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252498006381':
 - collection_name: 'Brill Online E-Books Middle Eastern Manuscripts Online 1: Pioneer Orientalists'
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/memo-1-pioneer-orientalists
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252498606381':
 - collection_name: 'Brill Online E-Books Middle Eastern Manuscripts Online 3: Arabic Manuscripts From The Hungarian Academy'
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/memo-3-arabic-manuscripts-from-the-hungarian-academy
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252499406381':
 - collection_name: Brill Online E-Books Cold War Intelligence
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/cold-war-intelligence
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252499606381':
 - collection_name: Early English Books Online
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/eebo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252644706381':
 - collection_name: 'Eighteenth Century Journals: Module IV Newspapers and Periodicals, 1708-1820'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.18thcjournals.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252645006381':
 - collection_name: Newsbank All Titles (Single Title access)
   interface_name: Newsbank, Inc.
   note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infoweb.newsbank.com/?db=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252645906381':
 - collection_name: Springer Nature - Springer Materials Landolt-Bornstein
   interface_name: SpringerNature
   note: SpringerNature. Authorized U-M users (+ guests in U-M Libraries)
   link: https://materials.springer.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252646406381':
 - collection_name: Everyday Life and Women in America, c.1800-1920
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.everydaylife.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252646506381':
 - collection_name: Defining Gender 1450-1910
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.gender.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252646606381':
 - collection_name: 'China: Trade, Politics and Culture, 1793-1980'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.china.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990116958010106381':
 - collection_name: APA PsycBooks
   interface_name: American Psychological Association
   note: American Psychological Association. Authorized U-M users (+ guests in U-M Libraries)
   link: http://content.apa.org/books/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
+- collection_name: APA PsycBooks
+  interface_name: American Psychological Association
+  note: American Psychological Association. Authorized U-M users (+ guests in U-M Libraries)
+  link: http://content.apa.org/books/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252650106381':
 - collection_name: 'Eighteenth Century Journals: Module III Newspapers and Periodicals, 1680-1813'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.18thcjournals.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252451506381':
 - collection_name: McGraw-Hill's AccessEngineering
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.accessengineeringlibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252452406381':
 - collection_name: World Bank E-Library Policy Research Working Papers
   interface_name: World Bank E-Library
   note: World Bank E-Library. Open access for all users.
   link: https://openknowledge.worldbank.org/entities/series/26e071dc-b0bf-409c-b982-df2970295c87
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252452706381':
 - collection_name: SAE International Journals
   interface_name: SAE Mobilus
   note: SAE Mobilus. Authorized U-M users (+ guests in U-M Libraries)
   link: https://saemobilus.sae.org/journals
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252452806381':
 - collection_name: ICE Virtual Library Books
   interface_name: ICE Virtual Library
   note: ICE Virtual Library. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.icevirtuallibrary.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252452906381':
 - collection_name: 'Eighteenth Century Journals: Module II Newspapers and Periodicals, 1699-1809'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.18thcjournals.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252453406381':
 - collection_name: 'Eighteenth Century Journals: Module I Newspapers and Periodicals, 1693-1790'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.18thcjournals.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252455706381':
 - collection_name: Springer Nature - Complete Protocols
   interface_name: SpringerNature
   note: SpringerNature. Authorized U-M users (+ guests in U-M Libraries)
   link: https://experiments.springernature.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252455806381':
 - collection_name: Elsevier ScienceDirect Books
   interface_name: Elsevier ScienceDirect
   note: Elsevier ScienceDirect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.sciencedirect.com/browse/journals-and-books?contentType=BK
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252466006381':
 - collection_name: Physical Review Online Archive (PROLA)
   interface_name: American Physical Society
   note: American Physical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: http://prola.aps.org
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252466706381':
 - collection_name: OCLC FirstSearch ECO
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://partneraccess.oclc.org/wcpa/servlet/openurl?genre=article
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252467806381':
 - collection_name: Artech House
   interface_name: Artech House
   note: Artech House. Authorized U-M users (+ guests in U-M Libraries)
   link: https://us.artechhouse.com/CloudPublish/Patron.aspx?c=umich
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252468206381':
 - collection_name: Wiley Online Library Current Protocols
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://currentprotocols.onlinelibrary.wiley.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252468406381':
 - collection_name: Access Medicine Case Files Collection
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: https://casefiles.mhmedical.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252471906381':
 - collection_name: DOAJ Directory of Open Access Journals
   interface_name: DOAJ Directory of Open Access Journals
   note: DOAJ Directory of Open Access Journals. Link may lead to a DOAJ page. Use "Website" buttons on journal pages to go to the journal. Use "READ ONLINE" buttons on article pages to go to the article. Open access for all users.
   link: https://www.doaj.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252472206381':
 - collection_name: OAPEN
   interface_name: OAPEN Open
   note: OAPEN Open. Open access for all users.
   link: https://oapen.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252472406381':
 - collection_name: BMJ Open Access Journals
   interface_name: BMJ Online
   note: BMJ Online. Open access for all users.
   link: http://journals.bmj.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252473306381':
 - collection_name: Reveal Digital Independent Voices Open Access
   interface_name: JSTOR
   note: JSTOR. Open access for all users.
   link: https://www.jstor.org/site/reveal-digital/independent-voices/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252474906381':
 - collection_name: PubMed Central
   interface_name: PubMed Central
   note: PubMed Central.
   link: https://www.ncbi.nlm.nih.gov/pubmed/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252475506381':
 - collection_name: JSTOR Books Open Access
   interface_name: JSTOR
   note: JSTOR.
   link: https://www.jstor.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252475806381':
 - collection_name: Open Humanities Press
   interface_name: University of Michigan
   note: University of Michigan. Open access for all users.
   link: http://quod.lib.umich.edu/o/ohp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252476006381':
 - collection_name: Biodiversity Heritage Library
   interface_name: Biodiversity Heritage Library
   note: Biodiversity Heritage Library. Open access for all users.
   link: https://www.biodiversitylibrary.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99187252476106381':
+- collection_name: Open Book Publishers
+  interface_name: Open Book Publishers
+  note: Open Book Publishers. Open access for all users.
+  link: https://www.openbookpublishers.com/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99187252476206381':
+- collection_name: 'Chronicling America: Historic American newspapers'
+  interface_name: Library of Congress
+  note: Library of Congress.
+  link: https://www.loc.gov/collections/chronicling-america/about-this-collection/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252477406381':
 - collection_name: Brillonline Ebooks Companions To Classical Studies Online Iii
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/package/9789004249301
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252477506381':
 - collection_name: Studies On The Texts Of The Desert Of Judah Online
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/view/serial/STDO
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252477606381':
 - collection_name: Brillonline Ebooks Companions To Classical Studies Online Ii
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/view/package/9789004284869
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252611906381':
 - collection_name: John Benjamins Journals
   interface_name: John Benjamins Publishing Company
   note: John Benjamins Publishing Company. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.jbe-platform.com/content/journals/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252612506381':
 - collection_name: Punch Historical Archive, 1841-1992
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=PNCH&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252613106381':
 - collection_name: Liberty Magazine Historical Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=LBRT&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252613206381':
 - collection_name: The Independent Historical Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/inda?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252613306381':
 - collection_name: Daily Mail Historical Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infotrac.galegroup.com/itweb/umuser?db=DMHA
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252613406381':
 - collection_name: Air & Space and Smithsonian Magazine Archive (pre-2011)
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infotrac.galegroup.com/itweb/umuser?db=SMIT
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252614906381':
 - collection_name: Gale Literature Criticism
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/lco?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252615006381':
 - collection_name: 'Slavery and Anti-Slavery: A Transnational Archive Part I'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infotrac.galegroup.com/itweb/umuser?db=SAS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252615506381':
 - collection_name: AIAA Conference Proceedings
   interface_name: AIAA Aerospace Research Central
   note: AIAA Aerospace Research Central. Authorized U-M users (+ guests in U-M Libraries)
   link: https://arc.aiaa.org/action/showpublications?pubtype=meetingproc
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252616306381':
 - collection_name: Travel Writing, Spectacle and World History
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.travelwriting.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252616406381':
 - collection_name: 'Romanticism: Life, Literature and Landscape'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.romanticism.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252616606381':
 - collection_name: BMJ Journals
   interface_name: BMJ Online
   note: BMJ Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.bmj.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252617306381':
 - collection_name: China, America and the Pacific
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.cap.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99187252617606381':
+- collection_name: World Newspaper Archive
+  interface_name: Readex
+  note: Readex. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://infoweb.newsbank.com/apps/readex?p=WHNPX
+  status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252618106381':
 - collection_name: 'Popular Culture in Britain and America 1950-1975: Module I'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.rockandroll.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252619406381':
 - collection_name: ARTFL reference collection
   interface_name: University of Chicago Press
   note: University of Chicago Press.
   link: https://artfl-project.uchicago.edu/artfl-resources/artfl-reference-collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252619806381':
 - collection_name: Current Digest of the Russian Press (DA-CDRP)
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/350
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252620106381':
 - collection_name: Monumenta Germaniae Historica
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://clt.brepolis.net/eMGH/pages/QuickSearch.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252622306381':
 - collection_name: 'Confidential Print: Latin America, 1833-1969'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.confidentialprintlatinamerica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252622506381':
 - collection_name: Popular Medicine in America, 1800-1900
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.popularmedicine.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252622906381':
 - collection_name: 'Confidential Print: Africa, 1834-1966'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.confidentialprintafrica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252623006381':
 - collection_name: PharmacyLibrary
   interface_name: American Pharmacists Association
   note: American Pharmacists Association. Authorized U-M users (+ guests in U-M Libraries)
   link: https://pharmacylibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252623606381':
 - collection_name: 'Apartheid South Africa 1948-1980: 1948-1966'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.apartheidsouthafrica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252624606381':
 - collection_name: India, Raj and Empire
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.indiaraj.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252625306381':
 - collection_name: 'First World War Portal: Module II Propaganda & Recruitment'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.firstworldwar.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252625506381':
 - collection_name: 'First World War Portal: Module I Personal Experiences'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.firstworldwar.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252625606381':
 - collection_name: Cabell's Directory of Publishing Opportunities
   interface_name: Cabell's
   note: Cabell's. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.cabells.com/academic
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252625906381':
 - collection_name: 'First World War Portal: Module III Visual Perspectives and Narratives'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.firstworldwar.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252626206381':
 - collection_name: SPEC Kits
   interface_name: Association of Research Libraries
   note: Association of Research Libraries.
   link: https://publications.arl.org/spec_kits_all
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252626306381':
 - collection_name: Brepols Aristoteles Latinus Database
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://clt.brepolis.net/ald/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252626406381':
 - collection_name: 'Jewish Life in America, 1654-1954: Sources from the American Jewish Historical Society, New York'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jewishlife.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252626506381':
 - collection_name: OpinionArchives
   interface_name: OpinionArchives
   note: OpinionArchives. Authorized U-M users (+ guests in U-M Libraries)
   link: https://metasearch.opinionarchives.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990141179400106381':
 - collection_name: GeoScienceWorld eBooks Collection
   interface_name: GeoScienceWorld
   note: GeoScienceWorld. Authorized U-M users (+ guests in U-M Libraries)
   link: http://ebooks.geoscienceworld.org/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252627006381':
 - collection_name: 'Confidential Print: Middle East, 1839-1969'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.confidentialprintmiddleeast.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252627306381':
 - collection_name: Dictionary of Old English
   interface_name: University of Toronto
   note: University of Toronto. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dictionary.doe.utoronto.ca/doe/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252628506381':
 - collection_name: Classic Mexican Cinema
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/mexican-cinema
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252628706381':
 - collection_name: Yearbook of International Organizations
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ybio.brillonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252628906381':
 - collection_name: Google Magazines
   interface_name: Google.com
   note: Google.com. Open access for all users. Download and printing options are not available for all publications.
   link: http://www.google.com/books/magazines
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252629906381':
 - collection_name: Virginia Company Archives
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.virginiacompanyarchives.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252630306381':
 - collection_name: 'Literary Manuscripts Leeds: Sources from The Brotherton Library, University of Leeds'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.literarymanuscriptsleeds.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252630406381':
 - collection_name: Macmillan Cabinet Papers, 1957-1963
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.macmillancabinetpapers.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252631406381':
 - collection_name: PERSEE - Portail de revues scientifiques en sciences humaines et sociales
   interface_name: Persee
   note: Persee.
   link: http://www.persee.fr/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252631806381':
 - collection_name: Perdita Manuscripts, 1500-1700
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.perditamanuscripts.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252632306381':
 - collection_name: 'China: Culture and Society'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.chinacultureandsociety.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252632406381':
 - collection_name: Chicago Manual of Style Online
   interface_name: University of Chicago Press
   note: University of Chicago Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.chicagomanualofstyle.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252632606381':
 - collection_name: 'Popular Culture in Britain and America 1950-1975: Module II'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.rockandroll.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252632806381':
 - collection_name: 'Literary Manuscripts Berg: Victorian Manuscripts from the Henry W. and Albert A. Berg Collection, New York Public Library'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.literarymanuscriptsberg.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252632906381':
 - collection_name: Oxford Art Online
   interface_name: Oxford Art Online
   note: Oxford Art Online. 5 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordartonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252633006381':
 - collection_name: Nixon Years, 1969-1974
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thenixonyears.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252633606381':
 - collection_name: 'Confidential Print: North America, 1824-1961'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.confidentialprintnorthamerica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252633906381':
 - collection_name: African American Communities
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.africanamericancommunities.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252634006381':
 - collection_name: Women in the National Archives
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.womeninthenationalarchives.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252635506381':
 - collection_name: Women Writers Online
   interface_name: Northeastern University
   note: Northeastern University. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.wwp.northeastern.edu/wwo/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252636006381':
 - collection_name: 'Global Commodities: Trade, Exploration and Cultural Exchange'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.globalcommodities.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252638006381':
 - collection_name: Philosophy Documentation Center E-Collection
   interface_name: Philosophy Documentation Center
   note: Philosophy Documentation Center. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.pdcnet.org/collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252638306381':
 - collection_name: McGraw Hill Access Pediatrics
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: https://accesspediatrics.mhmedical.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252638706381':
 - collection_name: Gale Financial Times Historical Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=FTHA&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252639606381':
 - collection_name: McGraw-Hill AccessSurgery
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: http://accesssurgery.mhmedical.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252640106381':
 - collection_name: McGraw-Hill AccessEmergency Medicine
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: http://accessemergencymedicine.mhmedical.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252640206381':
 - collection_name: McGraw Hill Access Anesthesiology
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: http://accessanesthesiology.mhmedical.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252640406381':
 - collection_name: Liverpool University Press - Translated Texts for Historians E-Library
   interface_name: Liverpool University Press
   note: Liverpool University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.liverpooluniversitypress.co.uk/topic/collections/translated-texts-for-historians-e-library?target=titleSearch
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252640506381':
 - collection_name: McGraw-Hill AccessPharmacy
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: http://accesspharmacy.mhmedical.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252640606381':
 - collection_name: 'Gale Making of Modern Law: Legal Treatises, 1800-1926'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/moml?u=umich_law
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252640906381':
 - collection_name: Digitalia eJournals
   interface_name: Digitalia
   note: Digitalia. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.digitaliapublishing.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252641406381':
 - collection_name: 'Eighteenth Century Journals: Module V The Lady''s Magazine and other titles, 1712-1832'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.18thcjournals.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252641906381':
 - collection_name: Elsevier ClinicalKey Books
   interface_name: Elsevier ClinicalKey
   note: Elsevier ClinicalKey. Access to ebook PDFs requires personal registration. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.clinicalkey.com/dura/browse/bookchapter/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252642406381':
 - collection_name: Grand Tour
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.grandtour.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252642506381':
 - collection_name: 'Medieval Family Life: The Paston, Cely, Plumpton, Stonor and Armburgh Papers'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.medievalfamilylife.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252643206381':
 - collection_name: Bloomsbury Berg Fashion Library
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.bloomsburyfashioncentral.com/berg-fashion-library
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990042655240106381':
 - collection_name: Oxford Reference Library
   interface_name: Oxford Reference Online
   note: Oxford Reference Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordreference.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252644406381':
 - collection_name: ASME Digital Collection eBooks
   interface_name: ASME Digital Collection
   note: ASME Digital Collection. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ebooks.asmedigitalcollection.asme.org/ebooks
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: ASME Digital Collection eBooks
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://asmedigitalcollection.asme.org/aws-ebooks
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252577706381':
 - collection_name: 'Short Story Index Retrospective: 1915-1983 (H.W. Wilson)'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=sxr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252577806381':
 - collection_name: Reaxys
   interface_name: Elsevier ScienceDirect
   note: Elsevier ScienceDirect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.reaxys.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252577906381':
 - collection_name: Scopus
   interface_name: Elsevier BV
   note: Elsevier BV.
   link: https://www.scopus.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252578006381':
 - collection_name: Statista
   interface_name: Statista
   note: Statista.
   link: http://www.statista.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252578106381':
 - collection_name: Phyllis Lyon, Del Martin and the Daughters of Bilitis
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3lbz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252578206381':
 - collection_name: 'State Papers Online: Part II: The Tudors, Henry VIII to Elizabeth I, 1509-1603, State Papers Foreign, Ireland, Scotland, Borders and Acts of Privy Council'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/4FUI/SPOL?u=umuser&sid=bookmark-SPOL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252578306381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part F (2012)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252578406381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part H (2014)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252578606381':
 - collection_name: IEEE Xplore River Publishers eBooks Library
   interface_name: IEEE Xplore
   note: IEEE Xplore. Authorized U-M users (+ guests in U-M Libraries)
   link: http://ieeexplore.ieee.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99187252578706381':
+- collection_name: NewsBank Rand Daily Mail Archive
+  interface_name: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://infoweb.newsbank.com/apps/readex/welcome?p=HN-SARDM
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252579706381':
 - collection_name: East View Current Digest of the Chinese Press Digital Archive (DA-CDCP)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/1230
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252584706381':
 - collection_name: Allgemeines Künstlerlexikon/Artists of the World
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252587906381':
 - collection_name: 'Gale Business: Insights'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=GBIB&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252589006381':
 - collection_name: Trade Catalogues and the American Home
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.tradecatalogues.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252589206381':
 - collection_name: World's Fairs
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.worldsfairs.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252589506381':
 - collection_name: 'East India Company: Module I India Office Records, A - D: Trade, Governance and Empire, 1600-1947'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252589706381':
 - collection_name: Bloomsbury Collections All Titles
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.bloomsbury.com/dr/digital-resources/products/bloomsbury-collections/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Bloomsbury collections
   interface_name: ''
   note: ''
   link: https://www.dramaonlinelibrary.com/critical-studies-and-performance-practice
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252590206381':
 - collection_name: 'Meiji Japan: The Edward Sylvester Morse Collection from the Peabody Essex Museum, Salem'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.aap.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252591506381':
 - collection_name: 'JoVE Journal: Bioengineering'
   interface_name: Journal of Visualized Experiments (JoVE)
   note: Journal of Visualized Experiments (JoVE) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jove.com/journal/bioengineering
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252591606381':
 - collection_name: 'JoVE Journal: Behavior'
   interface_name: Journal of Visualized Experiments (JoVE)
   note: Journal of Visualized Experiments (JoVE) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jove.com/journal/behavior
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252591706381':
 - collection_name: 'JoVE Journal: Developmental Biology'
   interface_name: Journal of Visualized Experiments (JoVE)
   note: Journal of Visualized Experiments (JoVE) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jove.com/journal/developmental-biology
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252592106381':
 - collection_name: 'JoVE Journal: Biology'
   interface_name: Journal of Visualized Experiments (JoVE)
   note: Journal of Visualized Experiments (JoVE) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jove.com/research/biology
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252594306381':
 - collection_name: SAE Mobilus Technical Papers
   interface_name: SAE Mobilus
   note: SAE Mobilus. Authorized U-M users (no guest access)
   link: https://saemobilus.sae.org/technical-papers
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187964169906381':
 - collection_name: Elsevier Ebook-Agricultural, Biological, and Food Sciences 2018
   interface_name: Elsevier ScienceDirect
   note: Elsevier ScienceDirect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.sciencedirect.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252596406381':
 - collection_name: National Geographic Magazine Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infotrac.galegroup.com/itweb/umuser?db=NGMA
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252597906381':
 - collection_name: English Historical Documents
   interface_name: Routledge
   note: Routledge. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.englishhistoricaldocuments.com/protected/home
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252599706381':
 - collection_name: 'American History Module II: Civil War, Reconstruction and the Modern Era: 1860-1945'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.americanhistory.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252601006381':
 - collection_name: Missouri Botanical Garden Botanicus Collection
   interface_name: Missouri Botanical Garden
   note: Missouri Botanical Garden. Open access for all users.
   link: http://www.botanicus.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252601606381':
 - collection_name: Dental Historic Collection
   interface_name: University of Michigan Library
   note: University of Michigan Library. Open access for all users.
   link: http://quod.lib.umich.edu/d/dentalj/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252602706381':
 - collection_name: McGraw-Hill AccessNeurology
   interface_name: McGraw Hill Companies
   note: McGraw Hill Companies. Authorized U-M users (+ guests in U-M Libraries)
   link: https://neurology.mhmedical.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252602906381':
 - collection_name: Oxford Research Encyclopedias
   interface_name: Oxford Research Encyclopedias
   note: Oxford Research Encyclopedias. Authorized U-M users (+ guests in U-M Libraries)
   link: http://oxfordre.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252603106381':
 - collection_name: Making of America Books
   interface_name: University of Michigan Library
   note: University of Michigan Library. Open access for all users.
   link: https://quod.lib.umich.edu/m/moa/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252606206381':
 - collection_name: Mass Observation Online (Original)
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.massobservation.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252606606381':
 - collection_name: Digitalia Hispanica
   interface_name: Digitalia
   note: Digitalia. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.digitaliapublishing.com/ebooks
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252606706381':
 - collection_name: OECD iLibrary
   interface_name: OECD iLibrary
   note: OECD iLibrary. Open access for all users.
   link: https://www.oecd.org/en/publications.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252607306381':
 - collection_name: 'Mass Observation Online: Module III'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.massobservation.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252607406381':
 - collection_name: 'Mass Observation Online: Module IV'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.amdigital.co.uk/m-collections/collection/mass-observation-iv/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252607506381':
 - collection_name: 'Mass Observation Online: Module I'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.massobservation.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252607606381':
 - collection_name: 'Mass Observation Online: Module II'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.massobservation.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252609106381':
 - collection_name: 'Nineteenth Century UK Periodicals, Part II: Empire'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infotrac.galegroup.com/itweb/umuser?db=NCUK
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252609606381':
 - collection_name: Oxford Music Online
   interface_name: Oxford Music Online
   note: Oxford Music Online. 5 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordmusiconline.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727706381':
 - collection_name: Tropical Diseases Bulletin
   interface_name: CAB International
   note: CAB International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.cabidigitallibrary.org/action/doSearch?ConceptID=500589
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727806381':
 - collection_name: 'Digital National Security Archive (DNSA): Iran: The Making of U.S. Policy, 1977-1980'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ir
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727906381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part C (2004-2010)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252728006381':
 - collection_name: Visual Thesaurus
   interface_name: Thinkmap, Inc
   note: Thinkmap, Inc.
   link: http://visualthesaurus.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728106381':
 - collection_name: 'Digital National Security Archive (DNSA): Mexico-United States Counternarcotics Policy, 1969-2013'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_md
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728206381':
 - collection_name: InfoTech Trends
   interface_name: Information Technology Trends
   note: Information Technology Trends.
   link: http://www.infotechtrends.com/cgi-bin/cif/sub_pass.pl?ipsub=1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728306381':
 - collection_name: Global Economic Monitor (GEM)
   interface_name: World Bank
   note: World Bank.
   link: http://data.worldbank.org/data-catalog/global-economic-monitor
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728406381':
 - collection_name: Inspec Archive
   interface_name: Geofacets
   note: Geofacets. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.engineeringvillage.com/app/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728506381':
 - collection_name: Colorado's Historic Newspaper Collection
   interface_name: Colorado State Library
   note: Colorado State Library.
   link: http://www.coloradohistoricnewspapers.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728606381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part B (1980-2003)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252728706381':
 - collection_name: 'Digital National Security Archive (DNSA): Japan and the United States: Diplomatic, Security, and Economic Relations, Part III, 1961-2000'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_jt
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728806381':
 - collection_name: AES Electronic Library
   interface_name: Audio Engineering Society
   note: Audio Engineering Society. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.aes.org/e-lib/inst/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252728906381':
 - collection_name: 'Digital National Security Archive (DNSA): Japan and the United States: Diplomatic, Security, and Economic Relations, 1960-1976'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ju
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252729006381':
 - collection_name: Galante's Venture Capital & Private Equity Directory
   interface_name: Dow Jones
   note: Dow Jones.
   link: http://online.barrons.com/home-page
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252729106381':
 - collection_name: 'Digital National Security Archive (DNSA): Japan and the United States: Diplomatic, Security, and Economic Relations, 1977-1992'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ja
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252729506381':
 - collection_name: CensusCD+Maps
   interface_name: GeoLytics, Inc.
   note: GeoLytics, Inc.
   link: http://www.geolytics.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252729706381':
 - collection_name: Balance of Payments Statistics (Datasets)
   interface_name: International Monetary Fund
   note: International Monetary Fund.
   link: http://elibrary-data.imf.org/DataExplorer.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252729806381':
 - collection_name: 'Digital National Security Archive (DNSA): Peru: Human Rights, Drugs and Democracy, 1980-2000'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_pe
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252729906381':
 - collection_name: 'Evangelism and the Syria-Lebanon Mission: Correspondence of the Board of Foreign Missions, 1869-1910'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qoj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730006381':
 - collection_name: 'Digital National Security Archive (DNSA): Nicaragua: The Making of U.S. Policy, 1978-1990'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ni
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730206381':
 - collection_name: 'Digital National Security Archive (DNSA): Presidential Directives on National Security, Part I: From Truman to Clinton'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_pd
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730306381':
 - collection_name: 'National Farm Worker Ministry: Mobilizing Support for Migrant Workers, 1939-1985'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6tzj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730406381':
 - collection_name: Valley of the Shadow
   interface_name: Edward L. Ayers
   note: Edward L. Ayers.
   link: http://valley.vcdh.virginia.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730506381':
 - collection_name: British Campaign in Mesopotamia, 1914-1918
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6nxz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730606381':
 - collection_name: 'U.K. Parliamentary Papers: House of Commons 18th Century (1688-1834)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://parlipapers.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730806381':
 - collection_name: Bibliography of Asian Studies
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=bas
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252731006381':
 - collection_name: Web of Science Current Contents Connect
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/ccc/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252731106381':
 - collection_name: MarketLine Business Information Center
   interface_name: MarketLine
   note: MarketLine.
   link: http://www.marketlineinfo.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252731206381':
 - collection_name: "Chinese Maritime Customs Service: The Customs\x92 Gazette, 1869-1913"
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8sss/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252731406381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part H (2016)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252731506381':
 - collection_name: Handbook of the Birds of the World Alive
   interface_name: Lynx Edicions
   note: Lynx Edicions.
   link: http://www.hbw.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732006381':
 - collection_name: Google Images
   interface_name: Google.com
   note: Google.com.
   link: http://images.google.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732106381':
 - collection_name: ASM Failure Analysis Center
   interface_name: ASM International
   note: ASM International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dl.asminternational.org/failure-analysis
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732206381':
 - collection_name: 'Narcotic Addiction and Mental Health: The Clinical Papers of Lawrence Kolb Sr.'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6emz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732306381':
 - collection_name: Virginia Henderson International Nursing Library
   interface_name: Sigma Theta Tau International
   note: Sigma Theta Tau International.
   link: http://www.nursinglibrary.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732506381':
 - collection_name: 'Country Intelligence Reports/State Department''s Bureau of Intelligence and Research Reports: Japan'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8ktb/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732606381':
 - collection_name: Google
   interface_name: Google.com
   note: Google.com.
   link: http://www.google.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732706381':
 - collection_name: Electronic Books
   interface_name: OCLC
   note: OCLC.
   link: http://firstsearch.oclc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732806381':
 - collection_name: ASM Micrograph Center
   interface_name: ASM International
   note: ASM International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://matdata.asminternational.org/mgd
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252732906381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Nuclear History, 1969-1976: Weapons, Arms Control, and War Plans in an Age of Strategic Parity'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_46
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733006381':
 - collection_name: TBRC Core Text Collections, Collection 12
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org/%23!specials/core/ctc12
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733106381':
 - collection_name: Plunkett Research Online
   interface_name: Plunkett Research, Ltd
   note: Plunkett Research, Ltd.
   link: http://www.plunkettresearchonline.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733206381':
 - collection_name: JapanKnowledge 現代用語の基礎知識(Encyclopedia of contemporary words)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733306381':
 - collection_name: Issues & Controversies
   interface_name: InfoBase Publishers, Inc.
   note: InfoBase Publishers, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://online.infobaselearning.com/Direct.aspx?aid=16234&pid=WE57
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733506381':
 - collection_name: NATLEX
   interface_name: International Labour Organization
   note: International Labour Organization.
   link: http://natlex.ilo.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733706381':
 - collection_name: Encyclopedia of Associations - Gale Digital Library
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/i.do?p=GDL&sw=w&u=umuser&v=2.1&pg=BasicSearch&it=static&sid=bookmark-GDL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733806381':
 - collection_name: CancerLit
   interface_name: National Cancer Institute
   note: National Cancer Institute.
   link: http://www.cancer.gov/search/cancer_literature/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252733906381':
 - collection_name: 'Crisis in the Dominican Republic: Records of the U.S. State Department Central Files, February 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8ssq/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252734006381':
 - collection_name: 'Iter: Gateway to the Middle Ages and Renaissance'
   interface_name: University of Toronto
   note: University of Toronto. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.itergateway.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252734106381':
 - collection_name: Internet Movie Database Web site
   interface_name: IMDB
   note: IMDB.
   link: http://www.imdb.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252734206381':
 - collection_name: International Pharmaceutical Abstracts (Ovid)
   interface_name: Ovid
   note: Ovid. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ovidsp.ovid.com/ovidweb.cgi?T=JS&CSC=y&PAGE=main&D=ipab
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252734406381':
 - collection_name: Databases on the History of Contemporary Chinese Political Movements (Zhongguo dang dai zheng zhi yun dong shi shu ju ku)
   interface_name: Chinese University of Hong Kong Press
   note: Chinese University of Hong Kong Press.
   link: http://ccrd.usc.cuhk.edu.hk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252734506381':
 - collection_name: Middle Eastern & Central Asian Studies
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fxh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252734906381':
 - collection_name: NIST Chemistry WebBook
   interface_name: National Institute of Standards and Technology
   note: National Institute of Standards and Technology.
   link: http://webbook.nist.gov/chemistry/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252735106381':
 - collection_name: Chinese Electronic Theses and Dissertations
   interface_name: Airiti Inc.
   note: Airiti Inc.
   link: http://www.airitilibrary.com/Search/alThesisbrowse
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252735206381':
 - collection_name: CANSIM
   interface_name: Computing in the Humanities and Social Sciences (CHASS)
   note: Computing in the Humanities and Social Sciences (CHASS)
   link: http://datacenter2.chass.utoronto.ca/cansimdim/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252735306381':
 - collection_name: Integrum Profi
   interface_name: Integrum World Wide
   note: Integrum World Wide.
   link: https://aclient.integrum.ru/gate/?name=[client_id]
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252735406381':
 - collection_name: American FactFinder
   interface_name: U.S. Census Bureau
   note: U.S. Census Bureau.
   link: http://factfinder2.census.gov/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252735506381':
 - collection_name: 'Prize Papers Online: Atlas'
   interface_name: Brill
   note: Brill.
   link: http://primarysources.brillonline.com/browse/prize-papers-online-atlas
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252735906381':
 - collection_name: 'U.K. Parliamentary Papers: House of Commons 20th Century (1901-2003/04 session)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://parlipapers.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252736106381':
 - collection_name: AMED - The Allied and Complementary Medicine Database
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=amed
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252736206381':
 - collection_name: New York Public Library Digital Gallery
   interface_name: New York Public Library
   note: New York Public Library.
   link: http://digitalgallery.nypl.org/nypldigital/index.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252736406381':
 - collection_name: SS Low-Res Maps carto-bib
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252736506381':
 - collection_name: Soshoo
   interface_name: China INFOBANK Limited
   note: China INFOBANK Limited.
   link: http://www.soshoo.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252736606381':
 - collection_name: American Memory
   interface_name: Library of Congress
   note: Library of Congress.
   link: https://www.loc.gov/search/?fa=partof:american+memory
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252736706381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part J (2016)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252736906381':
 - collection_name: Making of the Modern World, Part II
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infotrac.gale.com/itweb/umuser?db=MOME
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252737106381':
 - collection_name: Web of Science BIOSIS Previews
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/biosis/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252737306381':
 - collection_name: 'Digital National Security Archive (DNSA): The Kissinger conversations, supplement II: A verbatim record of U.S. diplomacy, 1969-1977'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_47
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252737406381':
 - collection_name: ProQuest Executive Branch Documents, Part 3 (1940-1942)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252737506381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part I (2016)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252737706381':
 - collection_name: Beilstein Crossfire
   interface_name: Geofacets
   note: Geofacets.
   link: http://www.sciencedirect.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252737806381':
 - collection_name: ProQuest Executive Branch Documents, Part 2
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738006381':
 - collection_name: AFI Catalog
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/afi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738206381':
 - collection_name: Film Index International
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/fii
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738506381':
 - collection_name: 'U.K. Parliamentary Papers: House of Commons 19th Century (1801-1900)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://parlipapers.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738606381':
 - collection_name: Early Arabic Printed Books from the British Library (1475-1900)
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/eapb?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738706381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part G (2015)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738806381':
 - collection_name: 'Prize Papers Online 1: American Revolutionary War and Fourth Anglo-Dutch War'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/prize-papers-part-1-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252738906381':
 - collection_name: Nursing Reference Center Plus
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=nup
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252739006381':
 - collection_name: 'World Scholar: Latin America and the Caribbean Historical Archive'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/LACH?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739106381':
 - collection_name: Enhanced Electronic Grammars
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739206381':
 - collection_name: 'State Papers Online: Eighteenth Century, 1714-1782: Part II: State Papers Foreign – Low Countries and Germany'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/4GVN/SPOL?u=umuser&sid=bookmark-SPOL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739406381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions 2015
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739506381':
 - collection_name: International African Bibliography Online
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com/journal/key/iabi/html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739606381':
 - collection_name: Tourism Factbook
   interface_name: World Tourism Organization
   note: World Tourism Organization. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.e-unwto.org/loi/unwtotfb
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739706381':
 - collection_name: Foreign Broadcast Information Service (FBIS) daily reports 1941-1974
   interface_name: Readex
   note: Readex.
   link: http://infoweb.newsbank.com/?db=FBISX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739806381':
 - collection_name: UpToDate® Lexidrug™
   interface_name: Wolters Kluwer
   note: Wolters Kluwer. Authorized U-M users (+ guests in U-M Libraries)
   link: https://online.lexi.com/lco/action/home?siteid=68654
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252739906381':
 - collection_name: TBRC Core Text Collections, Collection 7
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740006381':
 - collection_name: Phase Equilibria Diagrams Online
   interface_name: American Ceramic Society, Inc.
   note: American Ceramic Society, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://phaseonline.ceramics.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740106381':
 - collection_name: Aozora Bunko (青空文庫)
   interface_name: National Diet Library
   note: National Diet Library.
   link: http://www.aozora.gr.jp/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740206381':
 - collection_name: RISM
   interface_name: RISM - Repertoire International des Sources Musicales
   note: RISM - Repertoire International des Sources Musicales. Open access for all users.
   link: http://opac.rism.info/index.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740406381':
 - collection_name: Encyclopædia Britannica
   interface_name: Encyclopaedia Britannica Inc
   note: Encyclopaedia Britannica Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://academic.eb.com/levels/collegiate
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740506381':
 - collection_name: TBRC Core Text Collections, Collection 6
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740606381':
 - collection_name: 'Overland Journeys: Travels in the West'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fiv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740706381':
 - collection_name: NTIS Database (National Technical Information Service)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ntis
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740806381':
 - collection_name: Meteorological & Geoastrophysical Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/mga
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252740906381':
 - collection_name: Arts:Search
   interface_name: Design Research Publications
   note: Design Research Publications.
   link: http://www.arts-search.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741006381':
 - collection_name: Communication Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=cax
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741106381':
 - collection_name: Intelligence Reports from the National Security Council's Vietnam Information Group, 1967-1975
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3rbf/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741206381':
 - collection_name: Witchcraft in Europe and America
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fit/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741306381':
 - collection_name: Aqualine
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/aqualine
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741406381':
 - collection_name: Sapiens Global Library
   interface_name: Sapiens Global Library
   note: Sapiens Global Library.
   link: http://www.glowm.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741506381':
 - collection_name: AGRICOLA
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/agricola
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741606381':
 - collection_name: Foreign Broadcast Information Service (FBIS) Daily Reports Annexes 1974-1996
   interface_name: Readex
   note: Readex.
   link: http://infoweb.newsbank.com/?db=FBISX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741706381':
 - collection_name: Bibliografia Generale della Lingua Italiana e della Letteratura Italiana (BiGLLI)
   interface_name: Salerno Editrice
   note: Salerno Editrice.
   link: http://www.bigli.it
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741806381':
 - collection_name: 'Ethnologue : Languages of the World'
   interface_name: SIL International
   note: SIL International. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.ethnologue.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252741906381':
 - collection_name: Creative Commons
   interface_name: Creative Commons
   note: Creative Commons.
   link: http://creativecommons.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742006381':
 - collection_name: SciVerse
   interface_name: Geofacets
   note: Geofacets.
   link: http://www.hub.sciverse.com/action/home/proceed
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742106381':
 - collection_name: Flavius Josephus Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://referenceworks.brillonline.com/browse/flavius-josephus-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742206381':
 - collection_name: 'U.S. Civilian Advisory Effort in Vietnam: U.S. Operations Mission, 1950-1954'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4QAV/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742306381':
 - collection_name: Missionary Archives from Lesotho, 1832 - 2006
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/missionary-archives-from-lesotho-1832-2006
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742506381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions, 2016
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742606381':
 - collection_name: 'Prize Papers Online 2: Seven Years’ War and War of the Austrian Succession'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/prize-papers-part-2-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742706381':
 - collection_name: Plumb's Veterinary Drugs
   interface_name: Brief Media
   note: Brief Media. Authorized U-M users (+ guests in U-M Libraries)
   link: http://academic.plumbs.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742806381':
 - collection_name: MindPapers
   interface_name: PhilPapers
   note: PhilPapers.
   link: http://consc.net/mindpapers
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252742906381':
 - collection_name: Arts + Architecture ProFILES (AAP)
   interface_name: Design Research Publications
   note: Design Research Publications.
   link: http://www.arts-search.com/database/index.php?tab=1&mode=advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743006381':
 - collection_name: 'Digital National Security Archive (DNSA): The President’s Daily Brief: Kennedy, Johnson and the CIA, 1961-1969'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_48
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743106381':
 - collection_name: Dissertations & Theses @ University of Michigan
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/pqdtlocal1006034
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743206381':
 - collection_name: OneMine.org
   interface_name: OneMine
   note: OneMine. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.onemine.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743306381':
 - collection_name: Public Affairs Index
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=p4h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743406381':
 - collection_name: Digital Public Library of America (DPLA)
   interface_name: Digital Public Library of America (DPLA)
   note: Digital Public Library of America (DPLA)
   link: http://dp.la/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743506381':
 - collection_name: TBRC Core Text Collections, Collection 10
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743606381':
 - collection_name: Bibliotheca Teubneriana Latina
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com/database/btl/html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252743706381':
 - collection_name: Art Theorists of the Italian Renaissance
   interface_name: Chadwyck-Healey
   note: Chadwyck-Healey.
   link: http://www.proquest.co.uk/en-UK/catalogs/databases/detail/arttheorists.shtml
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744006381':
 - collection_name: 'China INFOBANK: Global Business Information Library INFOBANK [INFOBANK环球商讯库]'
   interface_name: China INFOBANK Limited
   note: China INFOBANK Limited.
   link: http://www.infobank.cn/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744106381':
 - collection_name: Vault Online Career Library
   interface_name: Vault, Inc.
   note: Vault, Inc.
   link: http://www.vault.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744306381':
 - collection_name: International Debt Statistics
   interface_name: World Bank
   note: World Bank.
   link: http://data.worldbank.org/data-catalog/global-development-finance
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744406381':
 - collection_name: LUNA Commons
   interface_name: LUNA Imaging
   note: LUNA Imaging.
   link: http://www.lunacommons.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744606381':
 - collection_name: 'International Women''s Periodicals, 1786-1933: Social and Political Issues'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4zha/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744706381':
 - collection_name: AtoZ Maps Online
   interface_name: World Trade Press
   note: World Trade Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.atozmapsonline.com/?c=42DugEjZvS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252744906381':
 - collection_name: ASM Alloy Phase Diagram Center
   interface_name: ASM International
   note: ASM International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://asm.mpds.io/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745106381':
 - collection_name: UN Commodity Trade Statistics Database
   interface_name: United Nations
   note: United Nations.
   link: http://comtrade.un.org/db/default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745206381':
 - collection_name: EBSCOHost Databases
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.asp?profile=ehost
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745306381':
 - collection_name: Encyclopaedia of Islam Online (English)
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/ei3o
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745506381':
 - collection_name: Ad*Access
   interface_name: Duke University Press
   note: Duke University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://repository.duke.edu/dc/adaccess
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745606381':
 - collection_name: Catena digital archive of historic gardens and landscapes
   interface_name: Cornell University
   note: Cornell University.
   link: http://library24.library.cornell.edu:8280/luna/servlet/BardBar~1~1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745706381':
 - collection_name: JapanKnowledge日本人名大辞典(The Biographical Dictionary of Japan)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745806381':
 - collection_name: 'JapanKnowledge新版 歌舞伎事典(The Kabuki Dictionary: New Edition)'
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252745906381':
 - collection_name: JapanKnowledge新編 日本古典文学全集(The Complete Collection of Japanese Classical Literature, New Edition)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746006381':
 - collection_name: JapanKnowledge世界文学大事典(The Shueisha Dictionary of World Literature)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746106381':
 - collection_name: JapanKnowledge東洋文庫(Toyo Bunko (The Eastern Library))
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746206381':
 - collection_name: JapanKnowledge日本国語大辞典(Shogakukan Unabridged Dictionary of the Japanese Language)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746406381':
 - collection_name: JapanKnowledge Encyclopedia of Japan
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746506381':
 - collection_name: JapanKnowledgeニッポニカ・プラス(Nipponica Plus)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746606381':
 - collection_name: JapanKnowledge文庫クセジュ ベストセレクション(Collection ≪Que sais-je?≫ Best Selections)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746706381':
 - collection_name: JapanKnowledge日本歴史地名大系(Encyclopedia of Japanese Historical Place Names)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746806381':
 - collection_name: 'JapanKnowledge新版 能・狂言事典(The Noh and Kyogen Dictionary: New Edition)'
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252746906381':
 - collection_name: JapanKnowledge日本大百科全書(Complete Japanese Encyclopedia)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://www.jkn21.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747006381':
 - collection_name: 'Radical Scatters: Emily Dickinson''s Late Fragments and Related Texts, 1870-1886'
   interface_name: University of Nebraska at Lincoln
   note: University of Nebraska at Lincoln.
   link: http://radicalscatters.unl.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747106381':
 - collection_name: Justiz und NS-Verbrechen
   interface_name: Amsterdam University Press
   note: Amsterdam University Press.
   link: http://www.junsv.nl
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747206381':
 - collection_name: Orbis M&A
   interface_name: Bureau van Dijk Electronic Publishing (BvDEP)
   note: Bureau van Dijk Electronic Publishing (BvDEP)
   link: https://orbismanda.bvdinfo.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747306381':
 - collection_name: Catholic Periodical and Literature Index
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747406381':
 - collection_name: HathiTrust Digital Library Full View U.S. Only
   interface_name: HathiTrust
   note: HathiTrust.
   link: http://www.hathitrust.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747506381':
 - collection_name: VisualDx
   interface_name: Logical Images
   note: Logical Images.
   link: https://visualdx.com/visualdx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747606381':
 - collection_name: OnTheBoards.TV
-  interface_name: On the Boards
-  note: On the Boards.
+  interface_name: OntheBoards.tv
+  note: OntheBoards.tv. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.ontheboards.tv/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252747806381':
 - collection_name: LearningExpressLibrary.com
   interface_name: Learning Express
   note: Learning Express. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.learningexpresshub.com/learningexpresslibrary
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252747906381':
 - collection_name: Urban Studies Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=23h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748006381':
 - collection_name: STAT-USA
   interface_name: U.S. Department of Commerce
   note: U.S. Department of Commerce.
   link: http://www.usa.gov/Topics/Reference-Shelf/Data.shtml
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748106381':
 - collection_name: VetMed Resource
   interface_name: CAB International
   note: CAB International. 4 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.cabidigitallibrary.org/product/VE
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748206381':
 - collection_name: Bibliography and Index of Micropaleontology
   interface_name: Micropaleontology Press
   note: Micropaleontology Press.
   link: http://micropress.org/bim/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748406381':
 - collection_name: 'MAUSDNQ00000 - US: Retailing'
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748506381':
 - collection_name: Google Book Search
   interface_name: Google.com
   note: Google.com.
   link: http://book.google.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748706381':
 - collection_name: World Religion Database
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.worldreligiondatabase.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748806381':
 - collection_name: Play Index
   interface_name: EBSCOhost
   note: EBSCOhost. 4 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=pix
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252748906381':
 - collection_name: Papers of Sir Mark Sykes, 1879-1919
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.britishonlinearchives.co.uk/collection.php?cid=9781851171507
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749006381':
 - collection_name: Historical Statistics of the United States
   interface_name: Cambridge University Press
   note: Cambridge University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://hsus.cambridge.org/HSUSWeb/HSUSEntryServlet
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749106381':
 - collection_name: Columbia Gazetteer of the World
   interface_name: Columbia University Press
   note: Columbia University Press.
   link: http://www.columbiagazetteer.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990112346670106381':
 - collection_name: Data-Planet Statistical Datasets
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dataplanet.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749306381':
 - collection_name: Book Review Digest Plus (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=brd
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749406381':
 - collection_name: WorldCat Dissertations and Theses
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: https://firstsearch.oclc.org/dbname=WorldCatDissertations;FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749506381':
 - collection_name: 'MAUSDND00000 - US: Electronics'
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749606381':
 - collection_name: Inter-university Consortium for Political and Social Research
   interface_name: ICPSR
   note: ICPSR.
   link: http://www.icpsr.umich.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749706381':
 - collection_name: Web of Science Primary (SCIE, SSCI & AHCI)
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749806381':
 - collection_name: Essay and General Literature Index (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=egi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252749906381':
 - collection_name: Old Testament Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=oah
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252750006381':
 - collection_name: JSTOR Global Plants
   interface_name: JSTOR
   note: JSTOR. Authorized U-M users (+ guests in U-M Libraries)
   link: http://plants.jstor.org/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252750206381':
 - collection_name: MAIIEBO00000 - Academic International Reports
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550306381':
 - collection_name: THOMAS
   interface_name: Library of Congress
   note: Library of Congress.
   link: http://thomas.loc.gov/home/thomas.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550406381':
 - collection_name: LibGuides at UM-Flint
   interface_name: Springshare, Inc.
   note: Springshare, Inc.
   link: https://libguides.umflint.edu/
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '99187252550506381':
 - collection_name: 'Making of Modern Law: Foreign, Comparative and International Law, 1600-1926'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/mmlf?u=umich_law
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550606381':
 - collection_name: 'MAUSFIN00000 - US: Finance Intelligence'
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550706381':
 - collection_name: HarpWeek
   interface_name: Harpweek
   note: Harpweek.
   link: http://app.harpweek.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550806381':
 - collection_name: IPA Source
   interface_name: IPA Source
   note: IPA Source.
   link: https://www.ipasource.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252550906381':
 - collection_name: Short Story Index (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ssx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551006381':
 - collection_name: Health & Psychosocial Instruments (HAPI)
   interface_name: EBSCOhost
   note: EBSCOhost. 5 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=hpi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551106381':
 - collection_name: CQ Historic Documents
   interface_name: C Q Press
   note: C Q Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://sk.sagepub.com/cqpress/series/historic-documents
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551206381':
 - collection_name: Daniels' Orchestral Music Online
   interface_name: Scarecrow Press, Inc.
   note: Scarecrow Press, Inc.
   link: https://daniels-orchestral.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551306381':
 - collection_name: Waterloo Directory of English Newspapers and Periodicals, 1800 - 1900, Series 3
   interface_name: North Waterloo Academic Press
   note: North Waterloo Academic Press.
   link: http://www.victorianperiodicals.com/series3/title_search_start.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551406381':
 - collection_name: Foundation Directory
   interface_name: Foundation Center
   note: Foundation Center. Authorized U-M users (+ guests in U-M Libraries)
   link: http://fconline.fdncenter.org/ipl.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551506381':
 - collection_name: Vanderbilt Television News Archive
   interface_name: Vanderbilt University
   note: Vanderbilt University.
   link: https://tvnews.vanderbilt.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551706381':
 - collection_name: WorldCat (OCLC FirstSearch)
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: https://firstsearch.oclc.org/FSIP?timeout=1800&done=referer&dbname=WorldCat
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551806381':
 - collection_name: International Political Science Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252551906381':
 - collection_name: Global Road Warrior
   interface_name: World Trade Press
   note: World Trade Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.globalroadwarrior.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552006381':
 - collection_name: Digital Sanborn Maps, 1867-1970
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://digitalsanbornmaps.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552106381':
 - collection_name: World Shakespeare Bibliography Online
   interface_name: World Shakespeare Bibliography
   note: World Shakespeare Bibliography. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.worldshakesbib.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552206381':
 - collection_name: World Development Indicators (WDI)
   interface_name: World Bank
   note: World Bank. Open access for all users.
   link: http://data.worldbank.org/data-catalog/world-development-indicators
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552306381':
 - collection_name: 'Gale Literature: Contemporary Authors'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ca?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552506381':
 - collection_name: Pivot
   interface_name: ProQuest
   note: ProQuest. Access requires personal registration for some website features. Authorized U-M users (+ guests in U-M Libraries)
   link: https://pivot.proquest.com/funding_main
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552606381':
 - collection_name: Associations Unlimited
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/i.do?p=GDL&sw=w&u=umuser&v=2.1&pg=BasicSearch&it=static&sid=bookmark-GDL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552706381':
 - collection_name: ChiltonLibrary.com
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infotrac.galegroup.com/itweb/umuser?db=CHLL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552806381':
 - collection_name: 'ASFA: Aquatic Sciences and Fisheries Abstracts'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/asfa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252552906381':
 - collection_name: Water Resources Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/waterresources
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553006381':
 - collection_name: 'MAUSEWV00000 - US: Transport and Transportation'
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553106381':
 - collection_name: 群書類従(Gunsho Ruiju)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553206381':
 - collection_name: Index to Foreign Legal Periodicals (Ovid)
   interface_name: Ovid
   note: Ovid. Authorized U-M users (+ guests in U-M Libraries)
   link: http://gateway.ovid.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553306381':
 - collection_name: DYABOLA Archäologische Bibliographie (aktualisierte Version des Realkatalogs) 1956-Mar 2008
   interface_name: Biering & Brinkmann Verlag
   note: Biering & Brinkmann Verlag.
   link: http://www.dyabola.de/en/indexfrm.htm?page=http://www.dyabola.de/en/bases/bases.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553406381':
 - collection_name: NDL Search
   interface_name: National Diet Library
   note: National Diet Library.
   link: http://iss.ndl.go.jp/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553506381':
 - collection_name: Middle English Compendium-Hyperbibliography
   interface_name: University of Michigan
   note: University of Michigan.
   link: http://ets.umdl.umich.edu/h/hyperbib/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553606381':
 - collection_name: Environmental Engineering Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/environmentalengabstracts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553706381':
 - collection_name: British and Irish Archaeological Bibliography (BIAB)
   interface_name: Council for British Archaeology
   note: Council for British Archaeology.
   link: https://archaeologydataservice.ac.uk/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553806381':
 - collection_name: History of Science, Technology, and Medicine
   interface_name: OCLC
   note: OCLC.
   link: http://firstsearch.oclc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252553906381':
 - collection_name: Health and Safety Science Abstracts (Full archive)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/healthsafetyabstracts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554006381':
 - collection_name: National Criminal Justice Reference Service - Publications
   interface_name: National Criminal Justice Reference Service
   note: National Criminal Justice Reference Service.
   link: http://www.ncjrs.gov/app/search/advancedsearch.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554106381':
 - collection_name: National Palace Museum Online
   interface_name: National Palace Museum
   note: National Palace Museum.
   link: http://www.airiti.com/npmoln
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554206381':
 - collection_name: Engineered Materials Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/engineeringmaterialsabstracts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554306381':
 - collection_name: METADEX
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/metadex
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554506381':
 - collection_name: Pollution Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/pollution
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554606381':
 - collection_name: 'State Papers Online: Part IV: The Stuarts: James to Anne, 1603 – 1714: State Papers Foreign, Ireland; and Registers of the Privy Council'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/4FWC/SPOL?u=umuser&sid=bookmark-SPOL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554706381':
 - collection_name: Materials Business File
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/materialsbusfile
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554806381':
 - collection_name: Copper Technical Reference Library
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/copper
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252554906381':
 - collection_name: Editions & Adaptations of Shakespeare (Legacy)
   interface_name: Chadwyck-Healey
   note: Chadwyck-Healey.
   link: http://collections.chadwyck.com/eas/htxview?template=basic.htx&content=frameset.htx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555006381':
 - collection_name: PsycINFO 1887-Current
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=psyh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555106381':
 - collection_name: 'CAMIO: Catalog for Art Images Online'
   interface_name: OCLC
   note: OCLC.
   link: http://camio.oclc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555206381':
 - collection_name: Index to 19th Century American Art Periodicals
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=iap
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252555306381':
 - collection_name: Middle English Compendium-Dictionary
   interface_name: University of Michigan
   note: University of Michigan.
   link: http://ets.umdl.umich.edu/m/med/structure.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555406381':
 - collection_name: Web of Science
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/woscc/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555506381':
 - collection_name: Aluminium Industry Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/aluminumindustryabstracts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555606381':
 - collection_name: 続々群書類従(Gunsho Ruiju 3)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555706381':
 - collection_name: 続群書類従(Gunsho Ruiju 2)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555806381':
 - collection_name: Google Patent Search
   interface_name: Google.com
   note: Google.com.
   link: http://www.google.com/patents
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252555906381':
 - collection_name: Wellesley Index to Victorian Periodicals
   interface_name: Chadwyck-Healey
   note: Chadwyck-Healey.
   link: http://wellesley.chadwyck.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556206381':
 - collection_name: TOXLINE
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/toxline
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556306381':
 - collection_name: Encyclopedia of Language and Linguistics
   interface_name: Geofacets
   note: Geofacets.
   link: http://www.sciencedirect.com/science/referenceworks/0080448542
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556406381':
 - collection_name: Duxiu
   interface_name: Superstar Information Technology co. Ltd
   note: Superstar Information Technology co. Ltd.
   link: http://www.duxiu.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556506381':
 - collection_name: Africa-Wide Information
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=awn
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556606381':
 - collection_name: NLM Gateway
   interface_name: National Library of Medicine
   note: National Library of Medicine.
   link: https://wwwcf.nlm.nih.gov/hsr_project/home_proj.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556806381':
 - collection_name: 'Afghanistan and the U.S., 1945-1963: Records of the U.S. State Department Classified Files'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3ijk/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252556906381':
 - collection_name: Electronics & Communications Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/electronicscomms
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557006381':
 - collection_name: ARTFL (American and French Research on the Treasury of the French Language)
   interface_name: University of Chicago Press
   note: University of Chicago Press.
   link: http://artfl-project.uchicago.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557106381':
 - collection_name: CiteSeerX
   interface_name: National Science Foundation
   note: National Science Foundation.
   link: https://citeseerx.ist.psu.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557206381':
 - collection_name: Evans Early American Imprint Collection - Text Creation Partnership
   interface_name: University of Michigan
   note: University of Michigan.
   link: https://quod.lib.umich.edu/e/evans/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557306381':
 - collection_name: Entrez
   interface_name: National Library of Medicine
   note: National Library of Medicine.
   link: http://www.ncbi.nlm.nih.gov/gquery/gquery.fcgi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557406381':
 - collection_name: Africa Development Indicators
   interface_name: World Bank
   note: World Bank.
   link: http://data.worldbank.org/data-catalog/africa-development-indicators
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557506381':
 - collection_name: 'European Colonialism in the Early 20th Century: Italian Colonies in North Africa and Aggression in East Africa, 1930-1939'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6tzg/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557606381':
 - collection_name: Alexander III and the Policy of Russification
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fiw/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557706381':
 - collection_name: eMarketer
   interface_name: eMarketer
   note: eMarketer.
   link: https://totalaccess.emarketer.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252557906381':
 - collection_name: American National Biography Online
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.anb.org/articles/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252558006381':
 - collection_name: 'Book Review Digest Retrospective: 1903-1982 (H.W. Wilson)'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=brr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252558106381':
 - collection_name: Bloomberg
   interface_name: Bloomberg
@@ -5790,8677 +11457,17254 @@
     Authorized U-M Ross School of Business users (+ guests in Kresge Library)
   link: https://search.lib.umich.edu/databases/record/9091
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252558206381':
 - collection_name: 'Feminism in Cuba: Nineteenth through Twentieth Century Archival Documents'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fiu/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252558306381':
 - collection_name: Federal Surveillance of African Americans, 1920-1984
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3enb/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252558406381':
 - collection_name: arXiv.org
   interface_name: Cornell University
   note: Cornell University.
   link: https://arxiv.org/search/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252558506381':
 - collection_name: Design & Applied Arts Index (DAAI)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/daai
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252558606381':
 - collection_name: Alternative Press Index Archive
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=alr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252558806381':
 - collection_name: American Bibliography of Slavic, East European & Eurasian Studies (ABSEEES)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/direct.asp?db=sbh
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252559006381':
 - collection_name: 'Art Index Retrospective: 1929-1984'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=air
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252559106381':
 - collection_name: Bibliography of English Women Writers 1500-1640
   interface_name: University of Toronto
   note: University of Toronto. Authorized U-M users (+ guests in U-M Libraries)
   link: https://beww.iterpubs.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252559206381':
 - collection_name: Arts & Humanities Citation Index
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/woscc/search-with-editions?editions=WOS.AHCI
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252559306381':
 - collection_name: Family & Society Studies Worldwide
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=flh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252559406381':
 - collection_name: Compendex
   interface_name: Engineering Village
   note: Engineering Village.
   link: https://www.engineeringvillage.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252559606381':
 - collection_name: Database of Latin Dictionaries (DLD)
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://clt.brepolis.net/dld/Dictionaries/Search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252559706381':
 - collection_name: English Short Title Catalogue
   interface_name: British Library Board
   note: British Library Board.
   link: http://estc.bl.uk/F/?func=file&file_name=login-bl-estc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560106381':
 - collection_name: 'CHANT (CHinese ANcient Texts) : Han da wen ku.'
   interface_name: Chinese University of Hong Kong Press
   note: Chinese University of Hong Kong Press.
   link: http://www.chant.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560306381':
 - collection_name: Criminal Justice Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=cja
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560406381':
 - collection_name: BNI
   interface_name: BNI
   note: BNI.
   link: https://firstsearch.oclc.org/dbname=ERIC%253bFSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560506381':
 - collection_name: ArchiveGrid
   interface_name: OCLC
   note: OCLC.
   link: https://researchworks.oclc.org/archivegrid/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560606381':
 - collection_name: 'Chatham House Online Archive Module 1: 1920-1979'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/CHTM?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560706381':
 - collection_name: 'Early American Imprints, Series II: Shaw-Shoemaker, 1801-1819'
   interface_name: Readex
   note: Readex.
   link: http://infoweb.newsbank.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560806381':
 - collection_name: DRAM (Database of Recorded American Music)
   interface_name: Anthology of Recorded Music, Inc.
   note: Anthology of Recorded Music, Inc.
   link: http://www.dramonline.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252560906381':
 - collection_name: 'European Colonialism in the Early 20th Century: Political and Economic Consolidation of Portuguese Colonies in Africa, 1910-1929'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6tze/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561006381':
 - collection_name: AgeLine
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=gnh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561106381':
 - collection_name: AREAER Online (Annual report on exchange arrangements and exchange restrictions data)
   interface_name: International Monetary Fund
   note: International Monetary Fund.
   link: http://imfareaer.org/Areaer/Pages/Home.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561206381':
 - collection_name: EconLit
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/econlit
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561306381':
 - collection_name: Embase
   interface_name: Elsevier BV
   note: Elsevier BV.
   link: http://www.embase.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561406381':
 - collection_name: Brepols Cross Database Searchtool
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.brepolis.net
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561506381':
 - collection_name: BCC Research
   interface_name: BCC Research
   note: BCC Research. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.bccresearch.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561606381':
 - collection_name: ARTbibliographies Modern (ABM)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/artbibliographies
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252561706381':
 - collection_name: FBI Surveillance of James Forman and SNCC
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6ctn/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561806381':
 - collection_name: ArticleFirst
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://firstsearch.oclc.org/fsip?dbname=ArticleFirst&done=referer
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252561906381':
 - collection_name: 'Evangelism in Africa: Correspondence of the Board of Foreign Missions, 1835‐1910'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4hlw/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562006381':
 - collection_name: Bibliography of Indigenous Peoples in North America
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.asp?profile=ehost&defaultdb=fph
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562106381':
 - collection_name: BRENDA:The Comprehensive Enzyme Database
   interface_name: BRENDA Enzyme Database
   note: BRENDA Enzyme Database. Open access for all users.
   link: https://www.brenda-enzymes.info/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562206381':
 - collection_name: 'Electing the President: Proceedings of the Democratic National Conventions, 1832-1988'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6mmd/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562306381':
 - collection_name: 'Electing the President: Proceedings of the Republican National Conventions, 1856-1988'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6mme/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562406381':
 - collection_name: Dictionary of Medieval Latin from British Sources
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://clt.brepolis.net/dmlbs/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562506381':
 - collection_name: Design Abstracts Retrospective
   interface_name: Design Research Publications
   note: Design Research Publications.
   link: http://www.arts-search.com/database/index.php?tab=2&mode=advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562606381':
 - collection_name: Alternative Press Index
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=apn
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562706381':
 - collection_name: 'American Indian Correspondence: Presbyterian Historical Society Collection of Missionaries'''' Letters, 1833‐1893'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xny/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252562806381':
 - collection_name: Avery Index to Architectural Periodicals
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/avery
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252563006381':
 - collection_name: 'Cold War: Voices of Confrontation and Conciliation'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qop/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252563106381':
 - collection_name: DynaMed
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&custid=s1221850&profile=dmp&groupid=main
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252563206381':
 - collection_name: American Indian Movement and Native American Radicalism
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3hgb/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252563306381':
 - collection_name: 'European Colonialism in the Early 20th Century: French Colonialism in Africa: From Algeria to Madagascar, 1910-1930'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6tzf/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252563406381':
 - collection_name: Early English Books Online - Text Creation Partnership
   interface_name: University of Michigan
   note: University of Michigan.
   link: https://quod.lib.umich.edu/e/eebogroup
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252563606381':
 - collection_name: ERIC
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/eric
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252563706381':
 - collection_name: Foreign Relations Between the U.S. and Latin America and the Caribbean States, 1930-1944
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4xnx/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252563906381':
 - collection_name: Hollywood, Censorship, and the Motion Picture Production Code, 1927-1968
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5xpn/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252564006381':
 - collection_name: 'Middle East Online: Arab-Israeli relations, 1917-1970'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6acm/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252564206381':
 - collection_name: National Index to Chinese Newspapers & Periodicals
   interface_name: Shanghai Wenda Information
   note: Shanghai Wenda Information.
   link: http://www.cnbksy.com/ShanghaiLibrary/en/main.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252564606381':
 - collection_name: 'Hindu Conspiracy Cases: Activities of the Indian Independence Movement in the U.S., 1908-1933'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5540/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252564706381':
 - collection_name: 'Humanities & Social Sciences Index Retrospective: 1907-1984 (H.W. Wilson)'
   interface_name: EBSCOhost
   note: EBSCOhost. 3 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=hsr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252564906381':
 - collection_name: Inorganic Crystal Structure Database
   interface_name: FIZ Technik e.V.
   note: FIZ Technik e.V.
   link: http://icsd.fiz-karlsruhe.de
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565006381':
 - collection_name: INSPEC
   interface_name: Engineering Village
   note: Engineering Village. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.engineeringvillage2.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565106381':
 - collection_name: Indigenous Peoples of North America
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/indp?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565206381':
 - collection_name: Library & Information Science Abstracts (LISA)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/lisa
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252565306381':
 - collection_name: Linguistics and Language Behavior Abstracts (LLBA)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/llba
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565406381':
 - collection_name: International Bibliography of Art (IBA)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/iba
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565506381':
 - collection_name: iPoll Databank
   interface_name: Cornell University
   note: Cornell University.
   link: https://ropercenter.cornell.edu/CFIDE/cf/action/home/index.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565606381':
 - collection_name: 'India from Crown Rule to Republic, 1945-1949: Records of the U.S. State Department'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4suz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565706381':
 - collection_name: Left Index
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=fqh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252565806381':
 - collection_name: 'Making of Modern Law: Trials, 1600–1926'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/mmlt?u=umich_law
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566006381':
 - collection_name: Forrester
   interface_name: Forrester Research, Inc
   note: Forrester Research, Inc.
   link: http://www.forrester.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566106381':
 - collection_name: Foreign Broadcast Information Service (FBIS) daily reports 1974-1996
   interface_name: Readex
   note: Readex.
   link: http://infoweb.newsbank.com/?db=FBISX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566206381':
 - collection_name: Merck Index Online
   interface_name: Royal Society of Chemistry
   note: Royal Society of Chemistry.
   link: https://merckindex.rsc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566306381':
 - collection_name: Foreign Relations between Latin America and the Caribbean States
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fgr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566406381':
 - collection_name: Material ConneXion
   interface_name: Material ConneXion
   note: Material ConneXion.
   link: https://www.materialconnexion.com/search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566506381':
 - collection_name: Mergent Online
   interface_name: Mergent, Inc.
   note: Mergent, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.mergentonline.com/basicsearch.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566606381':
 - collection_name: 'Middle East Online: Iraq, 1914-1974'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6acn/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566706381':
 - collection_name: Music Index
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=mah
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566806381':
 - collection_name: Journal Citation Reports
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://jcr.clarivate.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252566906381':
 - collection_name: Index to Jewish Periodicals
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=jph
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252567006381':
 - collection_name: Johns Hopkins Guide to Literary Theory & Criticism
   interface_name: The Johns Hopkins University Press
   note: The Johns Hopkins University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://litguide.press.jhu.edu
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252567106381':
 - collection_name: 'Japanese-American Relocation Camp Newspapers: Perspectives on Day-to-Day Life'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4lkr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567206381':
 - collection_name: 'Jewish Underground Resistance: The David Diamant Collection, 1939-1945'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4mtr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567306381':
 - collection_name: MLA International Bibliography
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=mzh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567406381':
 - collection_name: MarketResearch.com Academic
   interface_name: MarketResearch.com
   note: MarketResearch.com.
   link: http://academic.marketresearch.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567506381':
 - collection_name: GPO Monthly Catalog
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://firstsearch.oclc.org/fsip?dbname=GPO&done=referer
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567606381':
 - collection_name: OAIster
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://firstsearch.oclc.org/fsip?dbname=OAIster&done=referer
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567706381':
 - collection_name: International Financial Statistics Online
   interface_name: International Monetary Fund
   note: International Monetary Fund.
   link: http://data.imf.org/ifs
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567806381':
 - collection_name: 'India-Pakistan Conflict: Records of the U.S. State Department, February 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8rkk/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252567906381':
 - collection_name: 'Making of Modern Law : U.S. Supreme Court Records and Briefs, 1832-1978'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/scrb?u=umich_law
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568006381':
 - collection_name: Finaeon
   interface_name: Global Financial Data
   note: Global Financial Data.
   link: https://app.finaeon.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568106381':
 - collection_name: Global Insight
   interface_name: I H S Inc.
   note: I H S Inc.
   link: http://myinsight.globalinsight.com/servlet/cats?pageContent=home&serviceID=4078
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568206381':
 - collection_name: Liberation Movement in Africa and African America
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3lcc/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568306381':
 - collection_name: Library, Information Science & Technology Abstracts (LISTA)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=IP,uid&profile=ehost&defaultdb=lxh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568406381':
 - collection_name: Foreign Broadcast Information Service Electronic Index
   interface_name: Newsbank, Inc.
-  note: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://infoweb.newsbank.com/?db=FBIS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568706381':
 - collection_name: Middle English Compendium
   interface_name: University of Michigan
   note: University of Michigan.
   link: https://quod.lib.umich.edu/m/middle-english-dictionary
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568806381':
 - collection_name: Global Market Information Database
   interface_name: Euromonitor International
   note: Euromonitor International.
   link: http://www.portal.euromonitor.com/portal/account/login
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252568906381':
 - collection_name: Government Finance Statistics
   interface_name: International Monetary Fund
   note: International Monetary Fund.
   link: http://data.imf.org/?sk=A0867067-D23C-4EBC-AD23-D3B015045405
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569006381':
 - collection_name: International Medieval Bibliography
   interface_name: Brepols Publishers
   note: Brepols Publishers. Select "IP recognition" for institutional access. Authorized U-M users (+ guests in U-M Libraries)
   link: https://cpps.brepolis.net/bmb/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569106381':
 - collection_name: Ideas Roadshow
   interface_name: Ideas Roadshow
   note: Ideas Roadshow. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ideasroadshow.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252569206381':
 - collection_name: Online Egyptological Bibliography (OEB)
   interface_name: University of Oxford
   note: University of Oxford. Authorized U-M users (+ guests in U-M Libraries)
   link: http://oeb.griffith.ox.ac.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569306381':
 - collection_name: 'Index to Legal Periodicals Retrospective: 1908-1981 (H.W. Wilson)'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=lpr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252569406381':
 - collection_name: 'Japan at War and Peace, 1930-1949: U.S. State Department Records on the Internal Affairs of Japan'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3ijn/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569506381':
 - collection_name: Joint Publications Research Service (JPRS) Reports, 1957-1994
   interface_name: Readex
   note: Readex.
   link: http://infoweb.newsbank.com?db=JPRSX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569606381':
 - collection_name: Index to Legal Periodicals & Books (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=lft
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569706381':
 - collection_name: John Milton Bibliography
   interface_name: University of Toronto
   note: University of Toronto. Authorized U-M users (+ guests in U-M Libraries)
   link: https://milton.iterpubs.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252569806381':
 - collection_name: SimplyAnalytics
   interface_name: Geographic Research, Inc
   note: Geographic Research, Inc. 5 concurrent user limit. Some website features require a personal account. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.simplyanalytics.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570006381':
 - collection_name: 'Psychological Warfare and Propaganda in World War II: Air Dropped and Shelled Leaflets and Periodicals'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4opx/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570106381':
 - collection_name: 'Politics, Social Activism and Community Support: Selected Gay and Lesbian Periodicals and Newsletters'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6jik/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570206381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions, 1789-2013
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570306381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part B (1980-1989)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252570406381':
 - collection_name: PAIS Index
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/pais
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570506381':
 - collection_name: 'State Papers Online: Eighteenth Century, 1714-1782 — Part I: State Papers Domestic, Military, Naval and the Registers of the Privy Council'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/4FWD/SPOL?u=umuser&sid=bookmark-SPOL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570606381':
 - collection_name: Tiananmen Square and U.S.‐China Relations, 1989‐1993
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3lbx/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252570806381':
 - collection_name: ProQuest Statistical Insight
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/statistical
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571006381':
 - collection_name: Social Sciences Citation Index
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/woscc/search-with-editions?editions=WOS.SSCI
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571106381':
 - collection_name: Roper Center Public Opinion Archives (with iPOLL)
   interface_name: Roper Center for Public Opinion Research
   note: Roper Center for Public Opinion Research.
   link: http://ropercenter.cornell.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571306381':
 - collection_name: ProQuest Congressional Hearings Digital Collection Unpublished Hearings Collection A (House 1973-1979)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252571406381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part B (2004-2010)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571506381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part A (1824-1979)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252571606381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part C (2011 forward)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571706381':
 - collection_name: Social Explorer
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.socialexplorer.com/pub/home/home.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571806381':
 - collection_name: ProceedingsFirst
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://firstsearch.oclc.org/fsip?dbname=Proceedings&done=referer
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252571906381':
 - collection_name: Science Citation Index Expanded
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/woscc/basic-searchhttps://www.webofscience.com/wos/woscc/search-with-editions?editions=WOS.SCI
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572306381':
 - collection_name: Republic of New Afrika
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3lca/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572406381':
 - collection_name: Ralph J. Bunche Oral Histories Collection on the Civil Rights Movement
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6orz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572506381':
 - collection_name: Policy Archive
   interface_name: Center for Governmental Studies (CGS)
   note: Center for Governmental Studies (CGS)
   link: https://www.policyarchive.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572606381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 1 (1789-1969)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252572706381':
 - collection_name: Sports Business Research Network
   interface_name: Sports Business Research Network
   note: Sports Business Research Network.
   link: https://www.sportsmarketanalytics.com/home.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572806381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part E (2013)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572906381':
 - collection_name: Peace Research Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=24h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573006381':
 - collection_name: U.S. Supreme Court Records and Briefs
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/scrb?u=umich_law
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573106381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Maps Digital Collection'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252573206381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part D (2004-2010)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252573406381':
 - collection_name: United Nations Treaty Collection
   interface_name: United Nations
   note: United Nations.
   link: https://treaties.un.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573506381':
 - collection_name: ulrichsweb.com
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://ulrichsweb.serialssolutions.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573606381':
 - collection_name: UNdata
   interface_name: United Nations
   note: United Nations.
   link: https://data.un.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573706381':
 - collection_name: PTSDpubs
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ptsdpubs
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573806381':
 - collection_name: 'State Papers Online: Part III: The Stuarts: James I to Anne, 1603-1714, State Papers Domestic'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/4FUJ/SPOL?u=umuser&sid=bookmark-SPOL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252573906381':
 - collection_name: 'State Papers Online: Part I: The Tudors, Henry VIII to Elizabeth I, 1509-1603, State Papers Domestic'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/4FUH/SPOL?u=umuser&sid=bookmark-SPOL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252574006381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part E (2011)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252574106381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part G (2013)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252574206381':
 - collection_name: 'Phyllis Lyon and Del Martin: Beyond the Daughters of Bilitis'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252574306381':
 - collection_name: Philosopher's Index
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/philosophersindex
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252574506381':
 - collection_name: 'Quest for Labor Equality in Household Work: National Domestic Workers Union, 1965-1979'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6ack/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252574806381':
 - collection_name: Social Science Research Network
   interface_name: Social Science Electronic Publishing, Inc.
   note: Social Science Electronic Publishing, Inc.
   link: http://ssrn.com/search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252574906381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part C (1990-2003)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252575006381':
 - collection_name: UN Comtrade
   interface_name: United Nations
   note: United Nations.
   link: http://comtrade.un.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575106381':
 - collection_name: PolicyMap
   interface_name: The Reinvestment Fund (TRF)
   note: The Reinvestment Fund (TRF) Authorized U-M users (+ guests in U-M Libraries)
   link: https://umich.policymap.com/newmaps%23/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575206381':
 - collection_name: Polling the Nations
   interface_name: Polling the Nations
   note: Polling the Nations. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ptn.infobase.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575306381':
 - collection_name: Sol and Evelyn Henkind Talmud Text Databank
   interface_name: Saul Lieberman Institute of Talmud Research of the Jewish Theological Seminary of America
   note: Saul Lieberman Institute of Talmud Research of the Jewish Theological Seminary of America. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.lieberman-institute.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575406381':
 - collection_name: Stalin Digital Archive
   interface_name: Yale University
   note: Yale University.
   link: http://www.stalindigitalarchive.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575506381':
 - collection_name: Congressional Statutes at Large
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/searchbynumber/bynumber
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575606381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part D (2012)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575706381':
 - collection_name: TRIP
   interface_name: TRIP
   note: TRIP. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.tripdatabase.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575806381':
 - collection_name: U.S. Declassified Documents Online
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=USDD&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252575906381':
 - collection_name: Psychoanalytic Electronic Publishing Archive
   interface_name: Psychoanalytic Electronic Publishing
   note: Psychoanalytic Electronic Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.pep-web.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252576306381':
 - collection_name: ProQuest Congressional Hearings Digital Collection Unpublished Hearings Collection B (House 1980, Senate 1985-1990)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252576406381':
 - collection_name: ProQuest Congressional Hearings Digital Collection Unpublished Hearings Collection C (House 1981-1982, Senate 1991-1992)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252576506381':
 - collection_name: PROJEKT DYABOLA
   interface_name: Biering & Brinkmann Verlag
   note: Biering & Brinkmann Verlag. Click on "Activate IP access" check-box. Select "Start." Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.dyabola.de
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252576606381':
 - collection_name: Social Science Electronic Data Library (SSEDL)
   interface_name: Sociometrics
   note: Sociometrics. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.socio.com/products/data
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252576706381':
 - collection_name: TRID
   interface_name: Transportation Research Board
   note: Transportation Research Board. Authorized U-M users (+ guests in U-M Libraries)
   link: http://trid.trb.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252577106381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part A (1970-1979)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252577206381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part F (2014)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252577306381':
 - collection_name: 'Readers'' Guide Retrospective: 1890-1982 (H.W. Wilson)'
   interface_name: EBSCOhost
   note: EBSCOhost. 4 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rgr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252577406381':
 - collection_name: PsycTHERAPY
   interface_name: American Psychological Association
   note: American Psychological Association. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.apa.org/pubs/databases/psyctherapy/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252577606381':
 - collection_name: Records of the Persian Gulf War
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3LBW/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252699706381':
 - collection_name: Index of Medieval Art
   interface_name: Index_Of_Medieval_Art
   note: Index_Of_Medieval_Art.
   link: https://theindex.princeton.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252699806381':
 - collection_name: East View Al-Ahram Digital Archive (DA-ALA)
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/alahram/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252699906381':
 - collection_name: Deep Blue Data at the University of Michigan
   interface_name: University of Michigan
   note: University of Michigan.
   link: https://deepblue.lib.umich.edu/data
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700006381':
 - collection_name: 'China and the Modern World: Hong Kong, Britain and China, 1841-1951'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/83MY/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700106381':
 - collection_name: International Herald Tribune Historical Archive 1887-2013
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/IHTO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700206381':
 - collection_name: Bibliographie Annuelle du Moyen Âge Tardif
   interface_name: BREPOLIS
   note: BREPOLIS.
   link: http://apps.brepolis.net/ltool/entrance.aspx?w=31
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700306381':
 - collection_name: Dictionnaire des Philosophes Antiques Online
   interface_name: BREPOLIS
   note: BREPOLIS.
   link: http://apps.brepolis.net/ltool/entrance.aspx?w=33
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700406381':
 - collection_name: Brill.com
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700506381':
 - collection_name: Trismegistos
   interface_name: Trismegistos
   note: Trismegistos.
   link: https://www.trismegistos.org/index.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700606381':
 - collection_name: Europa World of Learning
   interface_name: Europa World of Learning
   note: Europa World of Learning.
   link: http://www.worldoflearning.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700806381':
 - collection_name: Bibliography of British and Irish history
   interface_name: Brepols
   note: Brepols. Authorized U-M users (+ guests in U-M Libraries)
   link: http://cpps.brepolis.net/bbih/search.cfm?
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252700906381':
 - collection_name: Astrophysics Data System
   interface_name: Astrophysics Data System
   note: Astrophysics Data System.
   link: http://www.adsabs.harvard.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252701006381':
 - collection_name: Oxford University Press African American Studies Center
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordaasc.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252701106381':
 - collection_name: AP images
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
-  link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=apg
+  link: https://research.ebsco.com/c/72mzer?acr_values=uid&db=apg
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252701306381':
 - collection_name: ProQuest Dissertations & Theses Global
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/pqdtglobal1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252701406381':
 - collection_name: Revistas PUCP
   interface_name: Pontificia Universidad Católica del Perú
   note: Pontificia Universidad Católica del Perú.
   link: http://revistas.pucp.edu.pe/directorio
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252701506381':
 - collection_name: Index to Hebrew Periodicals (IHP)
   interface_name: IHP - Index to Hebrew Periodicals - מפתח חיפה למאמרים בעברית
   note: IHP - Index to Hebrew Periodicals - מפתח חיפה למאמרים בעברית.
   link: https://haifa-primo.hosted.exlibrisgroup.com/primo-explore/search?vid=IHP&lang=iw_IL
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252702606381':
 - collection_name: 'Prize Papers Online 3: First, Second and Third Anglo-Dutch War and War of the Spanish Succession'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/prize-papers-part-3-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252702706381':
 - collection_name: ERIC
   interface_name: ERIC
   note: ERIC. Authorized U-M users (+ guests in U-M Libraries)
   link: https://eric.ed.gov/
   status: Available
-'99187252703106381':
-- collection_name: Dartmouth Dante Project
-  interface_name: Dartmouth College
-  note: Dartmouth College. Open access for all users.
-  link: http://dante.dartmouth.edu/
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252703506381':
 - collection_name: Bibliography of the History of Art (BHA) and Répertoire international de la littérature de l'art (RILA)
   interface_name: Getty Trust
   note: Getty Trust.
   link: https://primo.getty.edu/primo-explore/search?vid=BHA&lang=en_US
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252703906381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part K (2017)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252704006381':
 - collection_name: 'Digital National Security Archive (DNSA): CIA Covert Operations III: From Kennedy to Nixon, 1961-1974'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_51
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704106381':
 - collection_name: 'Digital National Security Archive (DNSA): Targeting Iraq, Part 1: Planning, Invasion, and Occupation, 1997-2004'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_49
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704206381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions 2017
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704306381':
 - collection_name: Deep Blue at the University of Michigan
   interface_name: University of Michigan
   note: University of Michigan.
   link: http://deepblue.lib.umich.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Deep Blue Documents at the University of Michigan
   interface_name: University of Michigan Library, Deep Blue Repositories
   note: University of Michigan Library, Deep Blue Repositories.
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704606381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part I (2017)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704706381':
 - collection_name: ProQuest Congressional Record Permanent Digital Collection Part D (2006-2009)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704806381':
 - collection_name: 'Digital National Security Archive (DNSA): Cuba and the U.S.: The Declassified History of Negotiations to Normalize Relations, 1959-2016'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_50
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252704906381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part J (2017)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252705306381':
 - collection_name: Biography and Genealogy Master Index
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/pub/9780805779493/gdl?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252705506381':
 - collection_name: RILM Abstracts of Music Literature (1967 to Present only)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rft
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252705806381':
 - collection_name: Sunday Times Historical Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/stha?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252705906381':
 - collection_name: HLAS Online
   interface_name: Library of Congress
   note: Library of Congress.
   link: http://lcweb2.loc.gov/hlas/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706006381':
 - collection_name: Digital Library Production Service (DLPS)
   interface_name: University of Michigan
   note: University of Michigan.
   link: http://www.lib.umich.edu/lit/dlps/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706106381':
 - collection_name: USPTO Issued Patents
   interface_name: USPTO
   note: USPTO.
   link: http://www.uspto.gov/patft/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706306381':
 - collection_name: 'Archives of Sexuality and Gender: LGBTQ History and Culture Since 1940, Part I'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/2XYQ/AHSI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706606381':
 - collection_name: Perseus
   interface_name: Tufts University
   note: Tufts University.
   link: http://www.perseus.tufts.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706706381':
 - collection_name: Biography Index Past and Present (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=bit
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706806381':
 - collection_name: American Broadsides and Ephemera, Series I, 1760-1900
   interface_name: Readex
   note: Readex.
   link: http://infoweb.newsbank.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252706906381':
 - collection_name: Social Sciences Abstracts (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ssa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707006381':
 - collection_name: Book Citation Index
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/ccc/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707106381':
 - collection_name: North Carolina Newspaper Digitization Project
   interface_name: North Carolina State Archives
   note: North Carolina State Archives.
   link: https://archives.ncdcr.gov/researchers/collections/newspapers
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707206381':
 - collection_name: SPORTDiscus
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=sph
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252707306381':
 - collection_name: CUMINCAD
   interface_name: Association for Computer Aided Design in Architecture
   note: Association for Computer Aided Design in Architecture.
   link: http://cumincad.scix.net/cgi-bin/works/LoginForm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707406381':
 - collection_name: Federal Surveillance of the Partido Independentista Puertorriqueño
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4rjl/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707506381':
 - collection_name: Cross-National Time-Series Data Archive
   interface_name: Databanks International
   note: Databanks International.
   link: http://www.databanksinternational.com/32.html
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252707606381':
 - collection_name: TBRC Core Text Collections, Collection 9
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707806381':
 - collection_name: 太陽2（明34-39）(Taiyo 2)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252707906381':
 - collection_name: Alcohol Studies Database
   interface_name: Rutgers University
   note: Rutgers University.
   link: https://alcoholstudies.libraries.rutgers.edu/alcohol-studies-database
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708006381':
 - collection_name: 文芸倶楽部3（明40-大1）(Bungei Club 3)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708106381':
 - collection_name: 太陽3（明40-大1）(Taiyo 3)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708206381':
 - collection_name: China Masters Dissertations (中国优秀硕士学位论文全文数据库)
   interface_name: East View Information Services, Inc.
   note: East View Information Services, Inc.
   link: http://oversea.cnki.net/kns55/brief/result.aspx?dbPrefix=CMFD
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708306381':
 - collection_name: China Doctoral Dissertations (中国博士学位论文全文数据库)
   interface_name: East View Information Services, Inc.
   note: East View Information Services, Inc.
   link: https://oversea.cnki.net/kns?dbcode=CDMD
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708406381':
 - collection_name: SPINPlus
   interface_name: InfoEd International
   note: InfoEd International.
   link: http://www.infoed.org/home/officemenu.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708506381':
 - collection_name: Frost & Sullivan-Growth Partnership-Healthcare
   interface_name: Frost & Sullivan
   note: Frost & Sullivan. Authorized U-M users (no guest access)
   link: https://member.frost.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708606381':
 - collection_name: 文芸倶楽部2（明34-明39）(Bungei Club 2)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708706381':
 - collection_name: 'U.S. Military Advisory Effort in Vietnam: Military Assistance and Advisory Group, Vietnam, 1950-1964'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qon/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708806381':
 - collection_name: 太陽1（明28-36）(Taiyo 1)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252708906381':
 - collection_name: 文芸倶楽部1（明28-明33）(Bungei Club 1)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709006381':
 - collection_name: 校友会雑誌(Koyukai Zasshi)
   interface_name: NetAdvance
   note: NetAdvance.
   link: http://japanknowledge.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709106381':
 - collection_name: Mergent EventsData
   interface_name: Mergent, Inc.
   note: Mergent, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.eventsdata.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709206381':
 - collection_name: United Nations Commodity Trade Statistics Database (UN comtrade)
   interface_name: United Nations
   note: United Nations.
   link: https://comtradeplus.un.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709306381':
 - collection_name: Pew Social & Demographic Trends
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://www.pewsocialtrends.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709406381':
 - collection_name: journalism.org
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://www.journalism.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709506381':
 - collection_name: Pew Forum on Religion & Public Life
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://www.pewforum.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709606381':
 - collection_name: TBRC Core Text Collections, Collection 4
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709806381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part A (1830-2003)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252709906381':
 - collection_name: 'Confederate Newspapers: A Collection from Florida, Georgia, Tennessee, Virginia and Alabama'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4mts/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252710106381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part D (2011)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252710306381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part E (2012)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252710406381':
 - collection_name: ANZ Newsstand A&I Only
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/anznewsai
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252710606381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part C (2011)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252710706381':
 - collection_name: Pew Global Attitudes Project
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://www.pewglobal.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252710806381':
 - collection_name: Pew Research Center for the People & the Press
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://www.people-press.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252710906381':
 - collection_name: Pew Internet
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://www.pewinternet.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711006381':
 - collection_name: Pew Research Center Publications
   interface_name: Pew Research Center
   note: Pew Research Center.
   link: http://pewresearch.org/pubs/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711106381':
 - collection_name: 'In Response to the AIDS Crisis: Records of the National Commission on Acquired Immune Deficiency Syndrome, 1983-1994'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4mtt/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711206381':
 - collection_name: TBRC Core Text Collections, Collection 3
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711306381':
 - collection_name: 'Minutemen, 1961-1969: Evolution of the Militia Movement in America, Part I'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qoh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711506381':
 - collection_name: TBRC Core Text Collections, Collection 5
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711806381':
 - collection_name: TBRC Core Text Collections, Collection 2
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252711906381':
 - collection_name: TAIR, Arabidopsis Information Resource
   interface_name: Phoenix Bioinformatics Corporation
   note: Phoenix Bioinformatics Corporation.
   link: http://www.arabidopsis.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712006381':
 - collection_name: TBRC Core Text Collections, Collection 11
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org/%23!specials/core/ctc11
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712106381':
 - collection_name: TBRC Core Text Collections, Collection 1
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712206381':
 - collection_name: State Papers Online, 1509-1714
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/spol?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712406381':
 - collection_name: Mergent Supply Chain
   interface_name: Mergent, Inc.
   note: Mergent, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.mergentonline.com/horizonsearch.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712606381':
 - collection_name: Latin American Public Opinion Project
   interface_name: Vanderbilt University
   note: Vanderbilt University.
   link: http://www.vanderbilt.edu/lapop/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712806381':
 - collection_name: Correspondence of Arthur C. Murray, 3rd Viscount Elibank
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.britishonlinearchives.co.uk/collection.php?cid=9781851171491&sid=&keywords=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252712906381':
 - collection_name: Minutes of the Shanghai Municipal Council
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8ssr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713006381':
 - collection_name: French Mandate in The Lebanon, Christian-Muslim Relations, and the U.S. Consulate at Beirut, 1920-1941
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6jvs/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713106381':
 - collection_name: MedCalc 3000
   interface_name: Teton Data Systems
   note: Teton Data Systems.
   link: http://online.statref.com/MedCalc3kFrames.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252713206381':
 - collection_name: North-China Daily News & Herald Newspapers and Hong Lists (1850-1951) (字林洋行中英文报纸全文数据库)
   interface_name: Shanghai Library (上海图书馆上海科学技术情报研究)
   note: Shanghai Library (上海图书馆上海科学技术情报研究)
   link: http://www.cnbksy.com/home
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713306381':
 - collection_name: World News Digest
   interface_name: InfoBase Publishers, Inc.
   note: InfoBase Publishers, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://online.infobaselearning.com/Direct.aspx?aid=16234&pid=WE56
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713406381':
 - collection_name: Papers of the Company of Scotland Trading to Africa and the Indies, 1694-1709
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.britishonlinearchives.co.uk/collection.php?cid=9781851171873&sid=&keywords=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713506381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions, 2014
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713706381':
 - collection_name: Senate Executive Documents and Reports
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713806381':
 - collection_name: Dissertations & Theses @ Big Ten Academic Alliance
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/pqdtlocal1005857
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252713906381':
 - collection_name: ProQuest Congressional Record Permanent Digital Collection Part C (2002-2005)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714006381':
 - collection_name: Congressional Base
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714106381':
 - collection_name: Georef
   interface_name: Engineering Village
   note: Engineering Village.
   link: http://www.engineeringvillage.com/controller/servlet/Controller
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714206381':
 - collection_name: Berliner Philharmoniker Digital Concert Hall
   interface_name: Berliner Philharmoniker
   note: Berliner Philharmoniker. 5 concurrent user limit. Access requires personal registration. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.digitalconcerthall.com/en/tickets
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714306381':
 - collection_name: Bayeux Tapestry Digital Edition
   interface_name: Scholarly Digital Editions
   note: Scholarly Digital Editions. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.sd-editions.com/bayeux/online/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252714406381':
 - collection_name: ProQuest Executive Branch Documents, 1789-1932
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714506381':
 - collection_name: OpenHelix
   interface_name: OpenHelix
   note: OpenHelix.
   link: http://www.openhelix.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714606381':
 - collection_name: SAGE Stats
   interface_name: SAGE
   note: SAGE.
   link: http://data.sagepub.com/sagestats/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714706381':
 - collection_name: Humanities Abstracts (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=hma
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252714906381':
 - collection_name: National Palace Museum Database of Ch'ing Palace Memorials and Archives of the Grand Council
   interface_name: Tudor Tech System Co. Ltd
   note: Tudor Tech System Co. Ltd.
   link: http://npmhost.npm.gov.tw/tts/npmmeta/GC/indexcg.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715006381':
 - collection_name: Education Abstracts (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=eax
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715106381':
 - collection_name: Art Abstracts (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=aax
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990049188600106381':
 - collection_name: MADCAD.com
   interface_name: MADCAD.com
   note: MADCAD.com. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.madcad.com/library/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715306381':
 - collection_name: General Science Abstracts (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=gsa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715406381':
 - collection_name: Gujin Tushu Jicheng
   interface_name: East View Information Services
   note: East View Information Services.
   link: http://greatman.eastview.com/Chinesebookweb/home/index.asp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715506381':
 - collection_name: TBRC Core Text Collections, Collection 8
   interface_name: Tibetan Buddhist Resource Center
   note: Tibetan Buddhist Resource Center.
   link: http://www.tbrc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715606381':
 - collection_name: Library Literature & Information Science Index (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip&profile=ehost&defaultdb=lii
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715706381':
 - collection_name: Readers' Guide Abstracts (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rga
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715806381':
 - collection_name: SuperStar e-Book Collection
   interface_name: Chinamaxx Digital Libraries
   note: Chinamaxx Digital Libraries.
   link: http://www.chinamaxx.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252715906381':
 - collection_name: Gmelin Crossfire
   interface_name: Geofacets
   note: Geofacets.
   link: http://minerva.library.wisc.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252716006381':
 - collection_name: Rare Disease Database
   interface_name: National Organization for Rare Disorders, Inc.
   note: National Organization for Rare Disorders, Inc.
   link: https://rarediseases.org/rare-diseases/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252716106381':
 - collection_name: Litt's Drug Eruption and Reaction Database
   interface_name: Taylor & Francis
   note: Taylor & Francis. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.drugeruptiondata.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252716206381':
 - collection_name: Essay and General Literature Retrospective (H.W. Wilson)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=egr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252716306381':
 - collection_name: Percussion Orchestrations
   interface_name: Percussion Orchestrations
   note: Percussion Orchestrations.
   link: http://www.percorch.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252716506381':
 - collection_name: Getty thesaurus of geographic names online
   interface_name: Getty Conservation Institute
   note: Getty Conservation Institute.
   link: http://www.getty.edu/research/conducting_research/vocabularies/tgn/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252716806381':
 - collection_name: Taiwan Electronic Periodical Services
   interface_name: Airiti Inc.
   note: Airiti Inc.
   link: http://www.airiti.com/teps/ec/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188933250506381':
 - collection_name: British Online Archives
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252717006381':
 - collection_name: DYABOLA Sachkatalog der Römisch-Germanischen Kommission Frankfurt, 1992-Dez 2007
   interface_name: Biering & Brinkmann Verlag
   note: Biering & Brinkmann Verlag.
   link: http://www.dyabola.de/en/indexfrm.htm?page=http://www.dyabola.de/en/bases/bases.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252717106381':
 - collection_name: DYABOLA Zugangsverzeichnis des Deutsche Archäologischen Institutes Madrid, 1991- 2002
   interface_name: Biering & Brinkmann Verlag
   note: Biering & Brinkmann Verlag.
   link: http://www.dyabola.de/en/indexfrm.htm?page=http://www.dyabola.de/en/bases/bases.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252717406381':
 - collection_name: ASME Digital Collection
   interface_name: American Society of Mechanical Engineers
   note: American Society of Mechanical Engineers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://asmedigitalcollection.asme.org/index.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252717606381':
 - collection_name: 'Mountain People: Life and Culture in Appalachia'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xnl/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252717706381':
 - collection_name: Artnet Price Database Fine Art and Design
   interface_name: ArtNet Worldwide Inc.
   note: ArtNet Worldwide Inc.
   link: https://www.artnet.com/my-account/institutional
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252717906381':
 - collection_name: 'America in Protest: Records of Anti-Vietnam War Organizations - Vietnam Veterans Against the War'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xnv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718006381':
 - collection_name: 'World War II, Occupation, and the Civil War in Greece, 1940‐1949: Records of the U.S. State Department Classified Files'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqf/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718106381':
 - collection_name: BookPlus
   interface_name: Nichigai Associates, Inc.
   note: Nichigai Associates, Inc. 10 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://web.nichigai.jp/nos/nweb/book/search/?user_id=MIC&lang=0
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718206381':
 - collection_name: 'Savings and Loan Crisis: Loss of Public Trust and the Federal Bailout, 1989‐1993'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3rbe/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718306381':
 - collection_name: 'Digital National Security Archive (DNSA): Presidential Directives on National Security, Part II: From Truman to George W. Bush'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_pr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718406381':
 - collection_name: 'MAEUTTA00000 - Europe: Travel and Tourism Analyst (TTA)'
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718506381':
 - collection_name: 'Digital National Security Archive (DNSA): South Africa: The Making of U.S. Policy, 1962-1989'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_sa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718606381':
 - collection_name: 'Digital National Security Archive (DNSA): Terrorism and U.S. Policy, 1968-2002'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_te
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718706381':
 - collection_name: 'MAUKEYB00000 - UK: Clothing and Footwear'
   interface_name: Mintel International Group Ltd.
   note: Mintel International Group Ltd.
   link: http://academic.mintel.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718806381':
 - collection_name: 'Digital National Security Archive (DNSA): The Cuban Missile Crisis: 50th Anniversary Update'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_cm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252718906381':
 - collection_name: 'Digital National Security Archive (DNSA): The Berlin Crisis, 1958-1962'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_bc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719006381':
 - collection_name: 'Digital National Security Archive (DNSA): The National Security Agency: Organization and Operations, 1945-2009'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_hn
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719106381':
 - collection_name: Mergent WebReports
   interface_name: Mergent, Inc.
   note: Mergent, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://webreports.mergent.com/index.php?action=login
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719206381':
 - collection_name: 'Shanghai Municipal Council: The Municipal Gazette, 1908-1940'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8ssr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719306381':
 - collection_name: Gartner Core Research
   interface_name: Gartner, Inc.
   note: Gartner, Inc.
   link: http://www.gartner.com/RecognizedUser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719406381':
 - collection_name: 'Digital National Security Archive (DNSA): The Kissinger Transcripts: A Verbatim Record of U.S. Diplomacy, 1969-1977'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_kt
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719506381':
 - collection_name: Gnomon Online
   interface_name: Katholische Universität
   note: Katholische Universität.
   link: http://www.gnomon.ku-eichstaett.de/Gnomon/en/Gnomon.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719606381':
 - collection_name: 'Digital National Security Archive (DNSA): The Kissinger Telephone Conversations: A Verbatim Record of U.S. Diplomacy, 1969-1977'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ka
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719706381':
 - collection_name: 'Digital National Security Archive (DNSA): The Kissinger Conversations, Supplement: A Verbatim Record of U.S. Diplomacy, 1969-1977'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_kc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252719906381':
 - collection_name: NatMed Pro
   interface_name: Natural Standard
   note: Natural Standard. NatMed (access restricted; authentication may be required)
   link: https://naturalmedicines.therapeuticresearch.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720006381':
 - collection_name: 'Digital National Security Archive (DNSA): The Iran-Contra Affair: The Making of a Scandal, 1983-1988'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ic
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720106381':
 - collection_name: 'Digital National Security Archive (DNSA): The Cuban Missile Crisis, 1962'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_cc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720206381':
 - collection_name: anatomy.tv
   interface_name: Teton Data Systems
   note: Teton Data Systems. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.anatomy.tv/titles
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252720306381':
 - collection_name: 'Digital National Security Archive (DNSA): The Cuban Missile Crisis Revisited: An International Collection, From Bay of Pigs to Nuclear Brink'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_cu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720406381':
 - collection_name: 'Digital National Security Archive (DNSA): The United States and the Two Koreas (1969-2000)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ko
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720506381':
 - collection_name: BBC Shakespeare Plays
   interface_name: Ambrose Video Publishing, Inc.
   note: Ambrose Video Publishing, Inc. Select "BBC Shakespeare plays" for links to programs. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ambrosevideo.com/institutional-access
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720606381':
 - collection_name: 'Digital National Security Archive (DNSA): The U.S. Intelligence Community After 9/11'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_in
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720706381':
 - collection_name: LawInfoChina
   interface_name: Chinalawinfo Co.,Ltd
   note: Chinalawinfo Co.,Ltd.
   link: http://www.lawinfochina.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720806381':
 - collection_name: Hand Press Book Database
   interface_name: OCLC
   note: OCLC.
   link: http://firstsearch.oclc.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252720906381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part G (2014)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252721106381':
 - collection_name: 'ISI Proceedings: Science & Technology Proceedings'
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: http://isiknowledge.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721206381':
 - collection_name: 'U.S. Civilian Advisory Effort in Vietnam: U.S. Operations Mission, 1954-1957 -- Classified & Subject Files of the Executive Office'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6tzh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721306381':
 - collection_name: 'Digital National Security Archive (DNSA): The United States and the Two Koreas, Part II, 1969-2010'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_kr
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721406381':
 - collection_name: ASM Alloy Center
   interface_name: ASM International
   note: ASM International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://asm.mpds.io/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721506381':
 - collection_name: Science Accelerator
   interface_name: U.S. Department of Energy * Office of Scientific and Technical Information
   note: U.S. Department of Energy * Office of Scientific and Technical Information.
   link: http://www.osti.gov/resourcedescriptions.shtml
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721606381':
 - collection_name: 'Digital National Security Archive (DNSA): The Soviet Estimate: U.S. Analysis of the Soviet Union, 1947-1991'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_se
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721706381':
 - collection_name: 'Digital National Security Archive (DNSA): The Philippines: U.S. Policy During the Marcos Years, 1965-1986'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ph
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721806381':
 - collection_name: 'Bibliographie de Civilisation Medievale Online: International'
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://apps.brepolis.net/LTool/Entrance.aspx?w=42
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252721906381':
 - collection_name: 'Digital National Security Archive (DNSA): The U.S. Intelligence Community: Organization, Operations and Management, 1947-1989'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722006381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part F (2013)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252722106381':
 - collection_name: 'ANTE: Abstracts in New Technology & Engineering'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ante
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722206381':
 - collection_name: Anthropology Review Database (ARD)
   interface_name: University of Buffalo
   note: University of Buffalo.
   link: http://wings.buffalo.edu/ARD/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722406381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Military Uses of Space, 1945-1991'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ms
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722506381':
 - collection_name: IBISWorld Industry Market Research
   interface_name: IBISWorld
   note: IBISWorld. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.ibisworld.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722606381':
 - collection_name: Direction of Trade Statistics Browser
   interface_name: International Monetary Fund
   note: International Monetary Fund.
   link: http://data.imf.org/?sk=9D6028D4-F14A-464C-A2F2-59B2CD424B85
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722706381':
 - collection_name: Chinese Film and Newsreel Scripts from the Cultural Revolution Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/chinese-filmscript-and-advertisement-collection-19461985
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252722906381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Intelligence on Weapons of Mass Destruction: From World War II to Iraq'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_wm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723106381':
 - collection_name: COS Funding Opportunities
   interface_name: Community of Science
   note: Community of Science. Access requires personal registration for some website features. Authorized U-M users (+ guests in U-M Libraries)
   link: https://pivot.proquest.com/funding_main
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723206381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Intelligence and China: Collection, Analysis and Covert Action'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ci
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723306381':
 - collection_name: Protein Data Bank
   interface_name: Research Collaboratory for Structural Bioinformatics (RCSB)
   note: Research Collaboratory for Structural Bioinformatics (RCSB)
   link: https://www.rcsb.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723406381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Espionage and Intelligence, 1947-1996'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ep
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723506381':
 - collection_name: Community of Science (COS)
   interface_name: Community of Science
   note: Community of Science. Access requires personal registration for some website features. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.cos.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723606381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Nuclear History: Nuclear Arms and Politics in the Missile Age, 1955-1968'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_nh
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723706381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Nuclear Non-Proliferation Policy, 1945-1991'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_np
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252723806381':
 - collection_name: Middle English Compendium-Corpus
   interface_name: University of Michigan
   note: University of Michigan.
   link: http://quod.lib.umich.edu/c/cme/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724006381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Policy in the Vietnam War, Part I: 1954-1968'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_vi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724106381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Policy in the Vietnam War, Part II: 1969-1975'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_vw
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724206381':
 - collection_name: GuideStar
   interface_name: GuideStar
   note: GuideStar.
   link: http://www.guidestar.org/ipLogin.do
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724306381':
 - collection_name: Stanford Encyclopedia of Philosophy
   interface_name: Stanford University
   note: Stanford University.
   link: http://plato.stanford.edu/contents.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724406381':
 - collection_name: 'Digital National Security Archive (DNSA): CIA Covert Operations II: The Year of Intelligence, 1975'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ct
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252724506381':
 - collection_name: 'Post War Europe: Refugees, Exile and Resettlement, 1945-1950'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6aco/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724606381':
 - collection_name: RGE Monitor
   interface_name: RGE Monitor
   note: RGE Monitor.
   link: http://www.rgemonitor.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724706381':
 - collection_name: 'Digital National Security Archive (DNSA): Afghanistan: The Making of U.S. Policy, 1973-1990'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_af
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724806381':
 - collection_name: Diaolong Zhongguo Riben Guji Quanwen Jiansuo Ziliaoku (雕龍-中國日本古籍全文檢索資料庫) [Diaolong Full-text Database of Chinese & Japanese Ancient Books]
   interface_name: China Educational Books Import & Export Corporation
   note: China Educational Books Import & Export Corporation.
   link: https://hunteq.com/ancientc/ancientkm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252724906381':
 - collection_name: ReferenceUSA Businesses Database
   interface_name: Infogroup
   note: Infogroup.
   link: http://www.referenceusa.com/UsBusiness/Search/Quick/eee9c780e7dc47d7a8e0d36b2226e907
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725006381':
 - collection_name: 'Digital National Security Archive (DNSA): Argentina, 1975-1980: The Making of U.S. Human Rights Policy'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ar
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725106381':
 - collection_name: International Nuclear Information System (INIS)
   interface_name: International Atomic Energy Agency
   note: International Atomic Energy Agency.
   link: http://inis.iaea.org/search/advancedsearch.aspx?orig_q=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725206381':
 - collection_name: 'Digital National Security Archive (DNSA): China and the United States: From Hostility to Engagement, 1960-1998'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ch
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725306381':
 - collection_name: 'Digital National Security Archive (DNSA): Chile and the United States: U.S. Policy toward Democracy, Dictatorship, and Human Rights, 1970-1990'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_cl
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725406381':
 - collection_name: ReferenceUSA Residential Database
   interface_name: Infogroup
   note: Infogroup.
   link: http://www.referenceusa.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725606381':
 - collection_name: 'Digital National Security Archive (DNSA): CIA Covert Operations: From Carter to Obama, 1977-2010'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_co
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725706381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part I (2015)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/congressional
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252725806381':
 - collection_name: Hispanic-American Periodicals Index (HAPI)
   interface_name: University of California Regents
   note: University of California Regents.
   link: http://hapi.ucla.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252725906381':
 - collection_name: ProQuest Statistical Abstracts of the World
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://statabs.proquest.com/international/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726006381':
 - collection_name: 'Digital National Security Archive (DNSA): El Salvador: The Making of U.S. Policy, 1977-1984'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_es
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726106381':
 - collection_name: 'Digital National Security Archive (DNSA): Colombia and the United States: Political Violence, Narcotics, and Human Rights, 1948-2010'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_cd
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726206381':
 - collection_name: 'OBSERVER: News for the American Soldier in Vietnam, 1962-1973'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6mmb/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726306381':
 - collection_name: Isabel Diagnosis Checklist System
   interface_name: Isabel Healthcare
   note: Isabel Healthcare.
   link: http://www.isabelhealthcare.com/suggest_diagnoses_advanced/landing_page
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726406381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part H (2015)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187252726506381':
 - collection_name: Thomson Research
   interface_name: Thomson Financial
   note: Thomson Financial.
   link: http://www.thomson.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726606381':
 - collection_name: 'Digital National Security Archive (DNSA): Death Squads, Guerrilla War, Covert Ops, and Genocide: Guatemala and the United States, 1954-1999'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_gu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726806381':
 - collection_name: 'Digital National Security Archive (DNSA): CIA Family Jewels Indexed'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_fj
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252726906381':
 - collection_name: Espacenet
   interface_name: European Patent Office
   note: European Patent Office. Open access for all users.
   link: https://worldwide.espacenet.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727006381':
 - collection_name: 'Digital National Security Archive (DNSA): El Salvador: War, Peace, and Human Rights, 1980-1994'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_el
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727206381':
 - collection_name: 'Digital National Security Archive (DNSA): Electronic Surveillance and the National Security Agency: From Shamrock to Snowden'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_su
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727306381':
 - collection_name: 'Digital National Security Archive (DNSA): Iraqgate: Saddam Hussein, U.S. Policy and the Prelude to the Persian Gulf War, 1980-1994'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_ig
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727406381':
 - collection_name: Making of Modern Michigan
   interface_name: Michigan State University Libraries
   note: Michigan State University Libraries.
   link: http://mmm.lib.msu.edu/search/index.cfm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252727606381':
 - collection_name: Index Islamicus
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ich
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187415675106381':
 - collection_name: English Drama
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ed?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415675706381':
 - collection_name: African American Poetry
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/aap
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415656406381':
 - collection_name: Coronavirus Research Database
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/coronavirus
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415656706381':
 - collection_name: FIAF International Index to Film Periodicals
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/fiafindex
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415657706381':
 - collection_name: 'Music Online: Contemporary World Music - All Titles'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/womu
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187415657906381':
 - collection_name: Popular Music Library - All Titles
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/pops
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187415660206381':
 - collection_name: 'Digital National Security Archive (DNSA): Donald Rumsfeld''s Snowflakes, Part II: The Pentagon and U.S. Foreign Policy, 2004-2006'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_57
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415660806381':
 - collection_name: Film Scripts Online, Volume 1
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/afso
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415662106381':
 - collection_name: Black Studies Center
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/bsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415662506381':
 - collection_name: 'U.K. Parliamentary Papers: House of Commons Hansard (1803-2005)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://parlipapers.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415662706381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Nuclear Nonproliferation 2, Part I: From Atoms for Peace to the NPT, 1954-1968'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_53
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415663106381':
 - collection_name: 'ProQuest Historical Newspapers: The Atlanta Constitution'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpatlantaconstitution2
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187415663306381':
 - collection_name: ProQuest Publicly Available Content Database
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/publiccontent
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415664306381':
 - collection_name: Women and Social Movements in the United States, 1600-2000, edited by Judy Tzu-Chun Wu and Rebecca Plant, 2020 Edition
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/wass
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415667006381':
 - collection_name: ProQuest Technology Collection
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/technology1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415667306381':
 - collection_name: 'Digital National Security Archive (DNSA): Donald Rumsfeld''s Snowflakes, Part I: The Pentagon and U.S. Foreign Policy, 2001-2003'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_56
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415667806381':
 - collection_name: Video Journal of Counseling and Therapy
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/counseling-and-therapy-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415668706381':
 - collection_name: ABI/INFORM Collection
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/abicomplete
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415669506381':
 - collection_name: Women and Social Movements in Modern Empires since 1820 (Text)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/wasg
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415670306381':
 - collection_name: Women and Social Movements in Modern Empires since 1820 (Video)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/wasg
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415670506381':
 - collection_name: 'Digital National Security Archive (DNSA): Soviet-U.S. Relations: The End of the Cold War, 1985-1991'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_52
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415672006381':
 - collection_name: 'Sixties: Primary Documents and Personal Narratives 1960-1974 (Video)'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/the-sixties-primary-documents-and-personal-narratives-1960-1974-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99187415672306381':
+- collection_name: 'ProQuest Historical Newspapers: The Jewish Exponent'
+  interface_name: ProQuest
+  note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://www.proquest.com/hnpjewishexponent/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415672906381':
 - collection_name: America Latina en Video - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/latin-america-in-video
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187415674306381':
 - collection_name: Bertolt Brechts Werke
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/brecht
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187434542206381':
 - collection_name: Age of Exploration
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.exploration.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187434742406381':
 - collection_name: Elsevier ClinicalKey Journals
   interface_name: Elsevier ClinicalKey
   note: Elsevier ClinicalKey. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.clinicalkey.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187436541806381':
 - collection_name: World Bank E-Library Publications
   interface_name: World Bank E-Library
   note: World Bank E-Library. Open access for all users.
   link: https://www.worldbank.org/en/research
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990165947390106381':
 - collection_name: Global Press Archive
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187441643706381':
 - collection_name: ChoiceReviews online
   interface_name: American Library Association
   note: American Library Association. Authorized U-M users (+ guests in U-M Libraries)
   link: http://choicereviews.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187447412106381':
 - collection_name: EBSCOhost ATLA Religion Database with ATLASerials [RFH]
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rfh
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188116898506381':
 - collection_name: Rockefeller University Press
   interface_name: Rockefeller_University_Press
   note: Rockefeller_University_Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://rupress.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187448258506381':
 - collection_name: BMJ Journals Online Archive
   interface_name: BMJ Online
   note: BMJ Online. Authorized U-M users (+ guests in U-M Libraries)
   link: http://journals.bmj.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990136824050106381':
 - collection_name: China Digital Library Reference
   interface_name: ''
   note: ''
   link: http://www.apabi.com/michigan/?pid=foreign.search&dt=EBook&db=refbook&dc=1.6&hdc=1&cult=CN
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990091071030106381':
 - collection_name: China Digital Library Ebook
   interface_name: ''
   note: ''
   link: http://www.apabi.com/michigan/?pid=foreign.search&db=dlib&dt=EBook&dc=1.6&hdc=1&cult=CN
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990052383650106381':
 - collection_name: China online journals
   interface_name: ''
   note: Access to the Wan fang shu ju zhi shi fu wu ping tai restricted; authentication may be required.
   link: http://c.g.wanfangdata.com.cn/Periodical.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187454444406381':
 - collection_name: PubChem
   interface_name: National Library of Medicine
   note: National Library of Medicine.
   link: http://pubchem.ncbi.nlm.nih.gov/
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '99187454444706381':
 - collection_name: HeinOnline Gun Regulation and Legislation in America
   interface_name: Hein Online
   note: Hein Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://heinonline.org/HOL/Index?collection=gun
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187455960106381':
 - collection_name: Materials Science & Engineering Collection
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/materials_science
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '99187455960206381':
 - collection_name: 'Gale Literature: Dictionary of Literary Biography'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/DLBC?u=umuser&aty=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187457259306381':
 - collection_name: 'Gale In Context: Opposing Viewpoints'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infotrac.gale.com/itweb/umuser?db=OVIC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187457549906381':
 - collection_name: 'Leisure, Travel & Mass Culture: The History of Tourism'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.masstourism.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252588706381':
 - collection_name: 'Eighteenth Century Drama: Censorship, Society and the Stage'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eighteenthcenturydrama.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187459643706381':
 - collection_name: 'Gale OneFile: Hospitality and Tourism'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppth?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865854306381':
 - collection_name: Manchester Hive
   interface_name: Manchester University Press
   note: Manchester University Press.
   link: https://www.manchesterhive.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187462119106381':
 - collection_name: 'Middle Eastern Manuscripts Online 2: The Ottoman Legacy of Levinus Warner'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/memo-2-the-ottoman-legacy-of-levinus-warner
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187461936906381':
 - collection_name: IngentaConnect Open Access Journals
   interface_name: IngentaConnect
   note: IngentaConnect. Open access for all users.
   link: https://www.ingentaconnect.com/content/title?j_type=online&j_startat=aa&j_endat=af&j_pagesize=200&j_page=1&j_availability=free
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990151916810106381':
 - collection_name: Cambridge archive editions online.
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/1670
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187479504006381':
 - collection_name: 'Wiley Digital Archives : Royal Anthropological Institute of Great Britain and Ireland'
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.wileydigitalarchives.com/rai/location/cu/auth/
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '99187479507706381':
 - collection_name: 'Gale OneFile: Economics and Theory'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppbe?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865854206381':
 - collection_name: EZB-FREE-00999 freely available EZB journals
   interface_name: Ezb
   note: Ezb. Open access for all users.
   link: https://ezb.uni-regensburg.de/ezeit/index.phtml?bibid=AAAAA&colors=7&lang=en
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
+- collection_name: EZB-FREE-00999 freely available EZB journals
+  interface_name: Ezb
+  note: Ezb. Open access for all users.
+  link: https://ezb.uni-regensburg.de/ezeit/index.phtml?bibid=AAAAA&colors=7&lang=en
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187486195406381':
 - collection_name: 'Wiley Digital Archives : New York Academy of Sciences'
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.wileydigitalarchives.com/nyas/location/cu/auth/
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '99188073306306381':
 - collection_name: America's Historical Newspapers
   interface_name: Readex
   note: Readex. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infoweb.newsbank.com/apps/readex/?p=EANX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187490324806381':
 - collection_name: LA84 Foundation
   interface_name: LA84_Foundation
   note: LA84_Foundation. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.la84.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187493915606381':
 - collection_name: TVRain Research Database
   interface_name: ''
   note: New programming has been suspended as of March 3, 2022, but access remains available to the archived programming.
   link: https://tvrain.ru/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187493927806381':
 - collection_name: Nei ge da ku dang an =
   interface_name: ''
   note: Access to the Grand secretariat archives online version restricted; authentication may be required.
   link: Stable%20link:%20%20http://www.lib.umich.edu/database/link/48844
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187494610606381':
 - collection_name: Advanced Materials Research
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/AMR
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187494827606381':
 - collection_name: 'Archives of Sexuality and Gender: Sex and Sexuality, Sixteenth to Twentieth Century'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/8OKR/AHSI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187494827706381':
 - collection_name: 'Archives of Sexuality and Gender: LGBTQ History and Culture Since 1940, Part II'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/0071/AHSI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496413206381':
 - collection_name: Funk & Wagnalls New World Encyclopedia
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=funk
   status: Available
+  campuses:
+  - flint
+  institution_codes:
+  - MIFLIC
 '99187496896606381':
 - collection_name: 'Food and Drink in History: Module II'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foodanddrink.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496896706381':
 - collection_name: Food and Drink in History
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.foodanddrink.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496897706381':
 - collection_name: 'Church Missionary Society Periodicals: Module I'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.churchmissionarysociety.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496897806381':
 - collection_name: 'Church Missionary Society Periodicals: Module II'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.churchmissionarysociety.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187497086806381':
 - collection_name: 'Foreign Office Files for Japan, 1919-1952: Japanese Imperialism and the War in the Pacific, 1931-1945'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesjapan.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187497086906381':
 - collection_name: 'Foreign Office Files for Japan, 1919-1952: Japan and Great Power Status, 1919-1930'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesjapan.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187497087006381':
 - collection_name: 'Foreign Office Files for Japan, 1919-1952: Occupation of Japan, 1946-1952'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesjapan.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187497090706381':
 - collection_name: 'Colonial Africa in official statistics, 1821-1953 : African blue books, 1821-1953'
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.britishonlinearchives.co.uk/collection.php?cid=9781851172740
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496863306381':
 - collection_name: 'Sex & Sexuality, Module II: Self-Expression, Community and Identity'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.sexandsexuality.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496863806381':
 - collection_name: 'J. Walter Thompson: Advertising America'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jwtadvertisingamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496863906381':
 - collection_name: 'Frontier Life: Borderlands, Settlement and Colonial Encounters'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.frontierlife.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496864006381':
 - collection_name: Foreign Office Files for the Middle East III
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesmiddleeast.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496864106381':
 - collection_name: Foreign Office Files for the Middle East II
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesmiddleeast.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496864206381':
 - collection_name: Foreign Office Files for the Middle East I
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesmiddleeast.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496865106381':
 - collection_name: Foreign Office Files for India, Pakistan and Afghanistan 1972-1980, Afghanistan and the Cold War, Emergency Rule in India, and the Resumption of Civilian Rule in Pakistan
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesindia.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496865206381':
 - collection_name: Foreign Office Files for India, Pakistan and Afghanistan 1965-1971, South Asian Convicts and Independence for Bangladesh
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesindia.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496865306381':
 - collection_name: Foreign Office Files for India, Pakistan and Afghanistan 1947-1964, Independence, Partition and the Nehru Era
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilesindia.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496865806381':
 - collection_name: Foreign Office Files for China 1957-66, The Great Leap Forward
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefileschina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496866106381':
 - collection_name: Foreign Office Files for China 1930-37, The Long March, civil war in China and the Manchurian Crisis
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefileschina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496866706381':
 - collection_name: 'First World War: A Global Conflict'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.firstworldwar.amdigital.co.uk/Introduction/NatureAndScope/GlobalConflict
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496867206381':
 - collection_name: 'East India Company Module III: India Office Records, G: Factory Records for China, Japan and the Middle East, 1596 - 1870'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496867306381':
 - collection_name: 'East India Company Module II: Factory Records for South Asia and South East Asia'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'East India Company Module II: Factory Records for South Asia and South East Asia'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/4
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496868906381':
 - collection_name: Early Modern England
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.earlymodernengland.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496870206381':
 - collection_name: 'Colonial America, Module IV: Legislation and Politics in the Colonies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.colonialamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'Colonial America, Module IV: Legislation and Politics in the Colonies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496870306381':
 - collection_name: 'Colonial America Module III: The American Revolution'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496870406381':
 - collection_name: 'Colonial America Module II: Towards Revolution'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496870606381':
 - collection_name: 'AM Scholar: Church Missionary Society'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496873906381':
 - collection_name: Indigenous Histories and Cultures in North America
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.indigenoushistoriesandcultures.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496886706381':
 - collection_name: 'Colonial America Module I: Early Settlement, Expansion and Rivalries'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496886906381':
 - collection_name: Children's Literature and Culture
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.childrensliterature.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496887106381':
 - collection_name: 'Apartheid South Africa 1948-1980: 1976-1980'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.apartheidsouthafrica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496887206381':
 - collection_name: 'Apartheid South Africa 1948-1980: 1967-1975'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.apartheidsouthafrica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252618206381':
 - collection_name: 'American History Module I: Settlement, Commerce, Revolution and Reform: 1493-1859'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.americanhistory.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496895206381':
 - collection_name: America in World War Two
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.americainworldwartwo.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496895506381':
 - collection_name: 'Ethnomusicology: Global Field Recordings'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ethnomusicology.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496946906381':
 - collection_name: McGraw Hill Access Dermatology DxRx
   interface_name: McGraw Hill Access
   note: McGraw Hill Access. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dermatology.mhmedical.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187516114706381':
 - collection_name: 'London Low Life: Street Culture, Social Reform and the Victorian Underworld'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.londonlowlife.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'London Low Life: Street Culture, Social Reform and the Victorian Underworld'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.londonlowlife.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187516114806381':
 - collection_name: 'Literary Print Culture: The Stationer''s Company Archives'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.literaryprintculture.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187515911206381':
 - collection_name: Market Research and American Business, 1935-1965
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.marketresearch.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517643406381':
 - collection_name: 'Race Relations in America: Surveys and Papers from The Amistad Research Center, 1943-1970'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.racerelations.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517643606381':
 - collection_name: Poverty, Philanthropy and Social Conditions in Victorian Britain
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.poverty.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517643906381':
 - collection_name: 'Nineteenth Century Literary Society: The John Murray Publishing Archive'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.nineteenthcenturyliterarysociety.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517665206381':
 - collection_name: 'Medical Services and Warfare: Module I 1850-1927'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.medicalservicesandwarfare.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517456806381':
 - collection_name: Advances in Science and Technology
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/AST
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521842206381':
 - collection_name: Advanced Engineering Forum
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/AEF
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521842306381':
 - collection_name: Nano Hybrids and Composites
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/NHC
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521842506381':
 - collection_name: Journal of Nano Research
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/JNanoR
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521842606381':
 - collection_name: Journal of Metastable and Nanocrystalline Materials
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/JMNM
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521842806381':
 - collection_name: Journal of Biomimetics, Biomaterials and Biomedical Engineering
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/JBBBE
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521845306381':
 - collection_name: International Journal of Engineering Research in Africa
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/JERA
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521845706381':
 - collection_name: Solid State Phenomena
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/SSP
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521845806381':
 - collection_name: Materials Science Forum
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/MSF
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521845906381':
 - collection_name: Key Engineering Materials
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/KEM
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521847606381':
 - collection_name: Defect and Diffusion Forum
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/DDF
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521854606381':
 - collection_name: Applied Mechanics and Materials
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/AMM
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187521948606381':
 - collection_name: Science of Synthesis Reference Libraries
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-reference-library-54790.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521948706381':
 - collection_name: Science of Synthesis Knowledge Updates
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-knowledge-updates-54789.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521948806381':
 - collection_name: 'Science of Synthesis 6: Compounds with All Heteroatom Functions'
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-category-6-58736.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521948906381':
 - collection_name: 'Science of Synthesis 5: Compounds with One Carbon-Heteroatom Bonds'
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-category-5-58735.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521949006381':
 - collection_name: 'Science of Synthesis 4: Compounds with Two Carbon-Heteroatom Bonds'
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-category-4-58734.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521949106381':
 - collection_name: 'Science of Synthesis 3: Compounds with Four and Three Carbon-Heteroatom Bonds'
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-category-3-58732.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521949206381':
 - collection_name: 'Science of Synthesis 2: Hetarenes'
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-category-2-58731.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521949306381':
 - collection_name: 'Science of Synthesis 1: Organometallics'
   interface_name: Thieme Connect
   note: Thieme Connect. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thieme.de/en/thieme-chemistry/sos-category-1-58729.htm
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187521951406381':
 - collection_name: Cambridge Edition of the Works of Ben Jonson Online
   interface_name: Cambridge University Press
   note: Cambridge University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://universitypublishingonline.org/cambridge/benjonson/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187522032206381':
 - collection_name: 'Migration to New Worlds Module II: The Modern Era'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.migration.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187522032306381':
 - collection_name: 'Migration to New Worlds: Module I The Century of Immigration'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.migration.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187522033606381':
 - collection_name: 'Sex & Sexuality, Module I: Research Collections from The Kinsey Institute Library & Special Collections'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.sexandsexuality.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524388406381':
 - collection_name: eHRAF Archaeology
   interface_name: Human Relations Area Files, Inc.
   note: Human Relations Area Files, Inc.
   link: http://ehrafarchaeology.yale.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524482906381':
 - collection_name: 'Socialism on Film: Module III Culture & Society'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.socialismonfilm.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524483006381':
 - collection_name: 'Socialism on Film: Module II Newsreels & Magazines'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.socialismonfilm.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524483106381':
 - collection_name: 'Socialism on Film: Module I Wars & Revolutions'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.socialismonfilm.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524483206381':
 - collection_name: Slavery Abolition and Social Justice 1490-2007
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.slavery.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524483306381':
 - collection_name: 'Shakespeare''s Globe Archive: Theatres, Players & Performance'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.shakespearesglobearchive.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524483506381':
 - collection_name: Shakespeare in Performance
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.shakespeareinperformance.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524483906381':
 - collection_name: 'AM Scholar: Area Studies India'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524486506381':
 - collection_name: 'Service Newspapers of World War Two: Module I'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.servicenewspapers.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529668406381':
 - collection_name: China Local Gazetteers
   interface_name: Wanfang Data Co,. Ltd.
   note: Wanfang Data Co,. Ltd.
   link: http://fz.wanfangdata.com.cn/navigation/newNavigationFacet.do?q=DBID:FZ_New&filterValue=%25E5%2585%25A8%25E9%2583%25A8&type=list
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529375106381':
 - collection_name: Talmud Yerushalmi Citation Database
   interface_name: Talmud Yerushalmi Citation Database
   note: Talmud Yerushalmi Citation Database. Authorized U-M users (+ guests in U-M Libraries)
   link: https://yerushalmidb.com/default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187529564106381':
 - collection_name: 'AM Scholar: World War Two Studies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/ww2studies
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529564206381':
 - collection_name: 'AM Scholar: Women''s Studies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/womensstudies
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529564506381':
 - collection_name: 'AM Scholar: Missionary Studies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529564806381':
 - collection_name: 'AM Scholar: Medieval and Early Modern Studies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529564906381':
 - collection_name: 'AM Scholar: Literary Studies'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529565006381':
 - collection_name: 'AM Scholar: Business Economic and Labour History'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/buseconlab
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529565106381':
 - collection_name: 'AM Scholar: Area Studies Japan'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529565206381':
 - collection_name: 'AM Scholar: Area Studies China and Southeast Asia'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.researchsource.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529570906381':
 - collection_name: 'Victorian Popular Culture Module I: Spiritualism, Sensation and Magic'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.victorianpopularculture.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529571106381':
 - collection_name: 'Victorian Popular Culture Module III: Music Hall, Theatre and Popular Entertainment'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.victorianpopularculture.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529571206381':
 - collection_name: 'Victorian Popular Culture Module IV: Moving Pictures, Optical Entertainment and Cinema'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.victorianpopularculture.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529571306381':
 - collection_name: 'Victorian Popular Culture Module II: Circuses, Sideshows and Freaks'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.victorianpopularculture.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529614506381':
 - collection_name: Iter Italicum
   interface_name: University of Toronto
   note: University of Toronto. Moving to EBSCOhost in 2025. Authorized U-M users (+ guests in U-M Libraries)
   link: https://italicum.iterpubs.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529626006381':
 - collection_name: PsycTESTS
   interface_name: American Psychological Association
   note: American Psychological Association. Authorized U-M users (+ guests in U-M Libraries)
   link: https://psycnet.apa.org/PsycTESTS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252620406381':
 - collection_name: Library of Latin Texts - A
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://clt.brepolis.net/llta/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252618606381':
 - collection_name: Library of Latin Texts - B
   interface_name: Brepols Publishers
   note: Brepols Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: http://clt.brepolis.net/lltb/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529637406381':
 - collection_name: 'HeinOnline Slavery in America and the World: History, Culture & Law'
   interface_name: Hein Online
   note: Hein Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://heinonline.org/HOL/Index?collection=slavery
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529528606381':
 - collection_name: Territorial Papers of the United States
   interface_name: Readex
   note: Readex. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infoweb.newsbank.com/apps/readex/?p=TERPX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529529206381':
 - collection_name: Early American Imprints, Series II, Shaw-Shoemaker Supplement from the Library Company of Philadelphia
   interface_name: Newsbank, Inc.
-  note: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infoweb.newsbank.com/?db=SHAW2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529529306381':
 - collection_name: 'Early American Imprints, Series I: Evans: Library Company of Philadelphia Supplements'
   interface_name: Newsbank, Inc.
-  note: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infoweb.newsbank.com/apps/readex/?p=EVAN2%C3%83%C2%82%C3%82%C2%A0
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529530006381':
 - collection_name: 'Political Extremism and Radicalism: Far-Right and Left Political Groups in the U.S., Europe, and Australia in the Twentieth Century'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://infotrac.galegroup.com/itweb/umuser?db=PLEX
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529530506381':
 - collection_name: Telegraph Historical Archive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/tgrh?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529531006381':
 - collection_name: Indigenous Newspapers in North America
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.indigenousnewspapersinnorthamerica.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529531506381':
 - collection_name: Thesaurus Linguae Latinae
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://tll.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529543306381':
 - collection_name: Medieval Travel Writing
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.medievaltravel.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187529294606381':
 - collection_name: Women and Social Movements in the United States, 1600-2000, edited by Judy Tzu-Chun Wu and Rebecca Plant, 2021 Edition
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/wass
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187542624706381':
 - collection_name: Gale Eighteenth Century Collections Online II
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ecco?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187542624806381':
 - collection_name: Gale Eighteenth Century Collections Online I
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ecco?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187542824206381':
 - collection_name: Black Liberation Army and the Program of Armed Struggle
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xnt/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187542825006381':
 - collection_name: Associated Press Collections Online
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/apoa?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187542825206381':
 - collection_name: 'Black Economic Empowerment: The National Negro Business League'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4lks/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187564130606381':
 - collection_name: 'Liberia and the U.S.: Nation-Building in Africa, 1864-1918'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://go.galegroup.com/gdsc/i.do?id=6TZI&v=2.1&u=umuser&it=aboutCollections&p=GDSC&sw=w
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187564218506381':
 - collection_name: American Veterinary Medical Association
   interface_name: American Veterinary Medical Association
   note: American Veterinary Medical Association. Authorized U-M users (+ guests in U-M Libraries)
   link: http://avmajournals.avma.org
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187564231606381':
 - collection_name: Papers of Amiri Baraka, Poet Laureate of the Black Power Movement
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3lby/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187564231706381':
 - collection_name: 'Women Organizing Transnationally: The Committee of Correspondence, 1952-1969'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xnw/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187564231806381':
 - collection_name: Women's Issues and Their Advocacy Within the White House, 1974-1977
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3FGT/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990155597790106381':
 - collection_name: Films on Demand World Cinema collection
   interface_name: Infobase
   note: Infobase. Authorized U-M users (+ guests in U-M Libraries)
   link: https://fod.infobase.com/PortalPlayLists.aspx?wid=16234
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '990175408700106381':
 - collection_name: Survei sosial ekonomi nasional (SUSENAS)
   interface_name: ''
   note: ''
   link: https://quod.lib.umich.edu/e/errwpc/umall/1/7/5/17540870.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570026106381':
 - collection_name: Final Accountability Rosters of Japanese-American Relocation Centers, 1944-1946
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4pqg/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570026406381':
 - collection_name: 'European Colonialism in the Early 20th Century: German Colonies to League of Nations Mandates in Africa 1910-1929'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6scr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570033906381':
 - collection_name: Drama Criticism
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/dynamicAboutSeries?p=LCO&u=umuser&seriesId=0XUS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Drama Criticism
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/lco?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570036006381':
 - collection_name: 'Gale OneFile: Contemporary Womens Issues'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/cwi?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570041406381':
 - collection_name: 'British Library Newspapers, Part IV: 1732-1950'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BNCN?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570041506381':
 - collection_name: 'British Library Newspapers, Part III: 1741-1950'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=BNCN&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570041606381':
 - collection_name: 'British Library Newspapers, Part V: 1746-1950'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/start.do?p=BNCN&u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047206381':
 - collection_name: 'Oxford Bibliographies Online: Sociology'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199756384
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047306381':
 - collection_name: 'Oxford Bibliographies Online: Social Work'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780195389678
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047406381':
 - collection_name: 'Oxford Bibliographies Online: Political Science'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199756223
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047506381':
 - collection_name: 'Oxford Bibliographies Online: Latino Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199913701
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047606381':
 - collection_name: 'Oxford Bibliographies Online: Latin American Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199766581
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047706381':
 - collection_name: 'Oxford Bibliographies Online: International Relations'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199743292
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047806381':
 - collection_name: 'Oxford Bibliographies : Evolutionary Biology'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780199941728
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570047906381':
 - collection_name: Oxford Bibliographies Online: Environmental Science
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199363445
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048006381':
 - collection_name: 'Oxford Bibliographies Online : Education'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199756810
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048106381':
 - collection_name: 'Oxford Bibliographies Online : Ecology'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780199830060
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048206381':
 - collection_name: 'Oxford Bibliographies Online: Criminology'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780195396607
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048306381':
 - collection_name: 'Oxford Bibliographies Online: Communication'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199756841
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048406381':
 - collection_name: 'Oxford Bibliographies Online: Classics'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780195389661
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048506381':
 - collection_name: 'Oxford Bibliographies Online: Cinema and Media Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199791286
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048606381':
 - collection_name: 'Oxford Bibliographies Online: Atlantic History'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?sticky=true&module_0=obo-9780199730414&q=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048706381':
 - collection_name: 'Oxford Bibliographies Online : Art History'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199920105
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570048906381':
 - collection_name: 'Oxford Bibliographies Online: African Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199846733
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187570049106381':
 - collection_name: 'Oxford Bibliographies Online: African American Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780190280024
   status: Available
-'99187570000306381':
-- collection_name: Gale Nineteenth Century Collections Online
-  interface_name: Gale
-  note: Gale. Authorized U-M users (+ guests in U-M Libraries)
-  link: https://link.gale.com/apps/ncco?u=umuser
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569874306381':
 - collection_name: MorphoBank
   interface_name: MorphoBank
   note: MorphoBank. Authorized U-M users (+ guests in U-M Libraries)
   link: https://morphobank.org/index.php
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569963406381':
 - collection_name: 'City and Business Directories: Louisiana, 1805-1929'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6cty/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569964106381':
 - collection_name: 'Chinese Civil War and U.S.-China Relations: Records of the U.S. State Department’s Office of Chinese Affairs, 1945-1955'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3ijl/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569965106381':
 - collection_name: Bush Presidency and Development and Debate Over Civil Rights Policy and Legislation
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xnr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569979106381':
 - collection_name: Ambassador Graham Martin and the Saigon Embassy's Back Channel Communication Files, 1963-1975
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4pqf/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569979906381':
 - collection_name: Allied Propaganda in World War II and the British Political Warfare Executive
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5xpw/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187569980006381':
 - collection_name: African America, Communists, and the National Negro Congress, 1933-1947
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5887/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187441541606381':
 - collection_name: Feature Films for Education
   interface_name: Infobase
   note: Infobase. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ffusa.infobase.com/PortalPlayLists.aspx?wid=16234
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187571941906381':
 - collection_name: 'Development of Environmental Health Policy: Pope A. Lawrence Papers 1924-1983'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qoo/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571942106381':
 - collection_name: 'Czechoslovakia from Liberation to Communist State, 1945‐63: Records of the U.S. State Department Classified Files'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqk/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571944506381':
 - collection_name: 'Country Intelligence Reports/State Department''s Bureau of Intelligence and Research Reports: China'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8kta/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571944606381':
 - collection_name: Correspondence from German Concentration Camps and Prisons 1936-1945
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4MTP/GDSC?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571944706381':
 - collection_name: Conditions & Politics in Occupied Western Europe, 1940-1945
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6acq/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571944806381':
 - collection_name: Commercial and Trade Relations Between Tsarist Russia, the Soviet Union and the U.S., 1910-1963
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5xpv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571945006381':
 - collection_name: Colección Revolución, 1910-1921
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6ctv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187571951506381':
 - collection_name: ClinMicroNow
   interface_name: American Society for Microbiology Press
   note: American Society for Microbiology Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.clinmicronow.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187572246306381':
 - collection_name: Almandumah Databases
   interface_name: Almandumah Databases
   note: Almandumah Databases. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.mandumah.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187572545006381':
 - collection_name: Dublin Castle Records, 1798‐1926
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqb/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187572839906381':
 - collection_name: 'European Colonialism in the Early 20th Century: German Colonies in Asia and the Pacific: From Colonialism to Japanese Mandates, 1910-1929'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5xps/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187572840006381':
 - collection_name: 'European Colonialism in the Early 20th Century: Colonialism and Nationalism in the Dutch East Indies, 1910-1930'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5xpq/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187573654006381':
 - collection_name: 'Gale In Context: College'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/CSIC?u=umuser&aty=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187573654106381':
 - collection_name: Franklin D. Roosevelt and Race Relations, 1933-1945
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8rkh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187573654206381':
 - collection_name: Fight for Racial Justice and the Civil Rights Congress
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5888/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187573654306381':
 - collection_name: Federal Response to Radicalism in the 1960s
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3ens/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187573655406381':
 - collection_name: 'Fannie Lou Hamer: Papers of a Civil Rights Activist, Political Activist, and Woman'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4zgy/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575452606381':
 - collection_name: U-M dissertations
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/pqdtlocal1006034?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575533806381':
 - collection_name: 'Gale OneFile: Physical Therapy and Sports Medicine'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppsm?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575534106381':
 - collection_name: 'Gale OneFile: Nursing and Allied Health'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppnu?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575534406381':
 - collection_name: 'Gale OneFile: Military and Intelligence'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppmi?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575534806381':
 - collection_name: 'Gale OneFile: Information Science'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppis?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575535506381':
 - collection_name: 'Gale OneFile: Gender Studies'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppgb?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575535906381':
 - collection_name: 'Gale OneFile: Gardening and Horticulture'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppgl?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575536006381':
 - collection_name: 'Gale OneFile: Fine Arts'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppfa?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575536906381':
 - collection_name: 'Gale OneFile: Environmental Studies and Policy'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppes?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575537206381':
 - collection_name: 'Gale OneFile: Entrepreneurship'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppsb?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575537506381':
 - collection_name: 'Gale OneFile: Educator''s Reference Complete'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/prof?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575545206381':
 - collection_name: 'Gale OneFile: Diversity Studies'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppds?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575545306381':
 - collection_name: 'Gale OneFile: Culinary Arts'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppca?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575545406381':
 - collection_name: 'Gale OneFile: Criminal Justice'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppcj?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575545706381':
 - collection_name: 'Gale OneFile: Agriculture'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppag?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575546206381':
 - collection_name: 'Gale Nineteenth Century Collections Online: Photography: The World Through the Lens'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/5YIY/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575547806381':
 - collection_name: 'Gale In Context: World History'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/WHIC?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575547906381':
 - collection_name: 'Gale In Context: U.S. History'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/uhic?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575548106381':
 - collection_name: 'Gale In Context: Science'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/scic?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575548506381':
 - collection_name: 'Gale In Context: Global Issues'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/GIC?u=umuser&aty=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575549006381':
 - collection_name: 'Gale In Context: Environmental Studies'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/grnr?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578883906381':
 - collection_name: Integration of Alabama Schools and the U.S. Military, 1963
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8rkj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578884206381':
 - collection_name: Industrial Mobilization in Britain and the Ministry of Munitions, 1915-1918
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5xpt/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578884406381':
 - collection_name: 'Indochina, France, and the Viet Minh War, 1945-1954: Records of the U.S. State Department, Part 1: 1945-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qol/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578890606381':
 - collection_name: 'Grassroots Civil Rights and Social Action: Council for Social Action'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8rkl/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578896306381':
 - collection_name: German Anti-Semitic Propaganda, 1909-1941
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6mma/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578900106381':
 - collection_name: 'Gale OneFile: World History'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppwh?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578900206381':
 - collection_name: 'Gale OneFile: Vocations and Careers'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppvc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578900306381':
 - collection_name: 'Gale OneFile: U.S. History'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppus?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578900606381':
 - collection_name: 'Gale OneFile: Religion and Philosophy'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/pprp?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578900706381':
 - collection_name: 'Gale OneFile: Psychology'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/pppc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187578902006381':
 - collection_name: 'Gale OneFile: Pop Culture Studies'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ppop?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579486006381':
 - collection_name: JFK's Foreign Affairs and International Crises, 1961-1963
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3enp/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579503606381':
 - collection_name: James Meredith, J. Edgar Hoover, and the Integration of the University of Mississippi
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3hga/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579980806381':
 - collection_name: Picture Post Historical Archive, 1938-1957
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/PIPO?u=umuser&aty=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579981906381':
 - collection_name: 'Papers of the Nixon Administration: The President''s Confidential and Subject Special Files, 1969-1974'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qog/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579986406381':
 - collection_name: 'Occupation and Independence: The Austrian Second Republic, 1945‐ 1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqe/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579986606381':
 - collection_name: 'Northern Ireland : A Divided Community 1921-1972 : Cabinet papers of the Stormont Administration'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6acr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579987106381':
 - collection_name: Newspapers of the French Revolution of 1848
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3xnn/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579834906381':
 - collection_name: Policing the Shanghai International Settlement, 1894‐1945
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fgp/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187579818306381':
 - collection_name: Global Health
   interface_name: CABI
   note: CABI. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.cabidigitallibrary.org/product/he
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187595775106381':
 - collection_name: 'Political, Economic, and Military Conditions in China: Reports and Correspondence of the U.S. Military Intelligence Division, 1918-1941'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4qoi/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252559506381':
 - collection_name: Dead Sea Scrolls Electronic Library Biblical Texts
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://referenceworks.brillonline.com/browse/dead-sea-scrolls-electronic-library-biblical-texts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187597668506381':
 - collection_name: Rastafari Ephemeral Publications from the Written Rastafari Archives Project
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8nja/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187598374006381':
 - collection_name: Reconstruction, Jim Crow, and the Enforcement of Federal Law in the South, 1871-1884
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8SSN/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187599250806381':
 - collection_name: 'Romania: Records of the U.S. Department of State; 1945-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9bri/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187599273506381':
 - collection_name: Gale Making of the Modern World Part 1
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/mome?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187599119006381':
 - collection_name: 'Digital National Security Archive (DNSA): CIA Covert Operations IV: The Eisenhower Years, 1953-1961'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_58
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187492100306381':
 - collection_name: Bloomsbury Theology and Religion Online Anchor Yale Bible Dictionary
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc.
   link: https://www.theologyandreligiononline.com/anchor-yale-bible-dictionary
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917979506381':
 - collection_name: ANU E Press
   interface_name: Australian National University (ANU)
   note: Australian National University (ANU) Open access for all users.
   link: http://press.anu.edu.au/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990088611000106381':
 - collection_name: JoVE Local
   interface_name: JoVE
   note: JoVE. Authorized U-M users (+ guests in U-M Libraries)
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187623206306381':
 - collection_name: 'ProQuest Historical Newspapers: Hindustan Times'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnphindustantimes
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188116898706381':
 - collection_name: Bristol University Press Digital
   interface_name: Bristol University Press Digital
   note: Bristol University Press Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://bristoluniversitypressdigital.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187626397006381':
 - collection_name: Patrologia Latina
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/patrologialatina
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187626397206381':
 - collection_name: Acta Sanctorum
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/actasanctorum
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187627194806381':
 - collection_name: Accuris Standards Store
   interface_name: Accuris
   note: Accuris. Authorized U-M users (+ guests in U-M Libraries)
   link: https://store.accuristech.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187629781406381':
 - collection_name: American Prison Newspapers
   interface_name: JSTOR
   note: JSTOR. Open access for all users.
   link: https://www.jstor.org/site/reveal-digital/american-prison-newspapers/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187629781906381':
 - collection_name: Student Activism
   interface_name: JSTOR
   note: JSTOR. Reveal Digital.
   link: https://www.jstor.org/site/reveal-digital/student-activism/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187633194206381':
 - collection_name: Computerized Index to Philippine Periodical Articles (CIPPA)
   interface_name: Rizal Library, Ateneo de Manila University
   note: Rizal Library, Ateneo de Manila University.
   link: http://rizal.lib.admu.edu.ph/cippa/cippa.asp
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187633375006381':
 - collection_name: The Icarus Films Fiction Collection
   interface_name: Docuseek2
   note: Docuseek2. Authorized U-M users (+ guests in U-M Libraries)
   link: http://docuseek2.com/v/c/rYo/if-fict
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187633375106381':
 - collection_name: Global Environmental Justice Collection
   interface_name: Docuseek2
   note: Docuseek2. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gej.docuseek2.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187633375206381':
 - collection_name: The Docuseek Complete Collection 3rd Edition Upgrade
   interface_name: Docuseek2
   note: Docuseek2. Authorized U-M users (+ guests in U-M Libraries)
   link: http://docuseek2.com/v/c/rYo/ds-3upgrd
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187633375306381':
 - collection_name: Docuseek2 Complete Collection
   interface_name: Docuseek2
   note: Docuseek2. Authorized U-M users (+ guests in U-M Libraries)
   link: http://docuseek2.com/v/c/rYo/ds-compl
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187634186006381':
 - collection_name: National Theatre Collection, Volume 2 (Video)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/national-theatre-collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187634186106381':
 - collection_name: National Theatre Collection, Volume 1 (Video)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/national-theatre-collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187596976506381':
 - collection_name: 'SAGE Video: Series - Sociology'
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://sk.sagepub.com/video/series/sociology
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575547606381':
 - collection_name: 'Gale Literature: LitFinder'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/LITF?u=umuser&aty=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990119343880106381':
 - collection_name: Farm, Field and Fireside Collection
   interface_name: Illinois Digital Newspaper Collections
   note: Illinois Digital Newspaper Collections. Open access for all users.
   link: https://idnc.library.illinois.edu/?a=p&p=collections&cltn=FFF&e=-------en-20--1--img-txIN----------
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187253735706381':
 - collection_name: Gazeta Wyborcza
   interface_name: ''
   note: Access to the Gazeta Wyborcza online version restricted; authentication may be required.
   link: https://wyborcza.pl/0,0.html
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187964252606381':
 - collection_name: IEEE Xplore All Courses
   interface_name: IEEE Xplore
   note: IEEE Xplore. Authorized U-M users (+ guests in U-M Libraries)
   link: https://ieeexplore.ieee.org/courses/home
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187674710406381':
 - collection_name: Art History Research Net (formerly Arts:Search)
   interface_name: Art History Research net
   note: Art History Research net. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.arthistoryresearch.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187675515506381':
 - collection_name: Mathematical Surveys and Monographs -2021
   interface_name: American Mathematical Society
   note: American Mathematical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ams.org/books/surv/year/2021/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188116898606381':
 - collection_name: CRL Newspapers
   interface_name: Center for Research Libraries
   note: Center for Research Libraries. Authorized U-M users (+ guests in U-M Libraries)
   link: http://catalog.crl.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187676209306381':
 - collection_name: 'Bloomsbury Collections: Classical Studies & Archaeology 2022'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.bloomsburycollections.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187675984806381':
 - collection_name: Jewish Chronicle Archive
   interface_name: Jewish Chronicle
   note: Jewish Chronicle. Access requires personal registration. Authorized U-M users (+ guests in U-M Libraries)
   link: https://archive.thejc.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187678402306381':
 - collection_name: Sezgin Online
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brillonline.com/cluster/Fuat%2520Sezgin%2520Online?s.num=0
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187678302206381':
 - collection_name: ACS In Focus Collection 1
   interface_name: American Chemical Society
   note: American Chemical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://pubs.acs.org/series/infocus
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187678906906381':
 - collection_name: Journal.fi
   interface_name: Journal.fi
   note: Journal.fi. Open access for all users.
   link: https://journal.fi
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187680402806381':
 - collection_name: Royal Geographical Society (with IBG)
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.wileydigitalarchives.com/rgs
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187680511906381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part O (2021)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680512006381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set Digital Collection 2, Part N (2020)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680512106381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set 2 Digital Collection, Part M (2019)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/congressional
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680512206381':
 - collection_name: 'ProQuest Congressional: U.S. Serial Set 2 Digital Collection, Part L (2018)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/congressional
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680512606381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part M (2020)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680512706381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part L (2019)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680512806381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part K (2018)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187680513006381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part N (2021)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187682305206381':
 - collection_name: Japan Times Archives
   interface_name: Japan Times
   note: Japan Times. Authorized U-M users (+ guests in U-M Libraries)
   link: https://jt-archives.jp/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187682178206381':
 - collection_name: 'East India Company: Module IV India Office Records, E: Correspondence: Early Voyages, Formation and Conflict'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187682178506381':
 - collection_name: Bridgeman Education
   interface_name: Bridgeman Art Library
   note: Bridgeman Art Library. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.bridgemaneducation.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187686512706381':
 - collection_name: Policy Commons
   interface_name: Coherent Digital
   note: Coherent Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://policycommons.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187686688206381':
 - collection_name: Singerman Bibliography of Antisemitic Texts in English
   interface_name: De Gruyter
   note: De Gruyter. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/database/SIBA/html?lang=en
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187688497906381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions 2019
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187688498006381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions 2018
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187688498106381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions 2021
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187688498206381':
 - collection_name: ProQuest Digital U.S. Bills and Resolutions 2020
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187689791206381':
 - collection_name: 'C19: The Nineteenth Century Index'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/c19index
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187690603806381':
 - collection_name: 'International Women''s Movement: The Pan Pacific Southeast Asia Women’s Association of the USA, 1950-1985'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4mtq/GDSC?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187690606606381':
 - collection_name: The Changing Men Collection Vertical Files
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60f1/gdsc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187690607706381':
 - collection_name: Transcripts of the Malcolm X Assassination Trial
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60gd/gdsc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187690610606381':
 - collection_name: 'Civil Rights and Social Activism in Alabama: The Papers of John LeFlore, 1926-1976 and Records of the Non-Partisan Voters League, 1956-1987'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZWD/GDSC?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040445006381':
 - collection_name: East View Essential Russian Classics
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2770
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187690594406381':
 - collection_name: World Scientific eBook complete package
   interface_name: World Scientific Publishing
   note: World Scientific Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.worldscientific.com/page/worldscibooks
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187694902306381':
 - collection_name: Medijski arhiv Ebart
   interface_name: ''
   note: Open access for all users.
   link: http://ip.arhiv.rs/novinska-arhiva/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187694864006381':
 - collection_name: Archive Finder
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/archivefinder
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187697013206381':
 - collection_name: 'ProQuest Congressional Research Digital Collection: Part J (2018)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187703907206381':
 - collection_name: EBSCOhost Art & Architecture Source
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?profile=ehost&defaultdb=asu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187707908406381':
 - collection_name: SAGE Journals Shallow Backfile Upgrade 2021
   interface_name: SAGE
   note: SAGE.
   link: https://journals.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187708592206381':
 - collection_name: Ogonek (St. Petersburg) Digital Archive (1899-1918)
   interface_name: ''
   note: Access to the Ogonek (St. Petersburg) Digital Archive (1899-1918) online version restricted; authentication may be required.
   link: https://dlib.eastview.com/browse/udb/3670
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187708592506381':
 - collection_name: Soviet Woman Digital Archive (1945-1991)
   interface_name: ''
   note: Access to the Soviet Woman Digital Archive (1945-1991) online version restricted; authentication may be required.
   link: https://dlib.eastview.com/browse/udb/3770
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990094695370106381':
 - collection_name: ICRG researcher dataset
   interface_name: University of Michigan Library
   note: University of Michigan Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://drive.google.com/drive/folders/1bOP661xZDlWGyZffXTJr62h1HiGDB9Ry
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187723482006381':
 - collection_name: COVE studio.
   interface_name: COVE Studio
   note: COVE Studio. Cove Studio (access restricted; authentication may be required)
   link: https://umich.covecollective.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496859906381':
 - collection_name: 학술논문 검색서비스 - earticle
   interface_name: e-articles
   note: e-articles. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.earticle.net/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187708581906381':
 - collection_name: Digital Theatre Plus Database
   interface_name: Digital Theatre+
   note: Digital Theatre+. Authorized U-M users (+ guests in U-M Libraries)
   link: https://edu.digitaltheatreplus.com/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187725788406381':
 - collection_name: The Guatemala Collection
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/the-guatemala-collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188044607406381':
 - collection_name: American Museum of Natural History Research Library
   interface_name: American Museum of Natural History Research Library
   note: American Museum of Natural History Research Library.
   link: http://digitallibrary.amnh.org/dspace/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187755011506381':
 - collection_name: ACS In Focus Collection 2
   interface_name: American Chemical Society
   note: American Chemical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.acs.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187755586506381':
 - collection_name: East View Late Qing and Republican-Era Chinese Newspapers
   interface_name: East View
   note: East View. Open access for all users.
   link: https://gpa.eastview.com/crl/lqrcn/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187755586606381':
 - collection_name: East View Independent and Revolutionary Mexican Newspapers
   interface_name: East View
   note: East View. Open access for all users.
   link: https://gpa.eastview.com/crl/irmn
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187755487706381':
 - collection_name: Project Gutenberg Online Catalog
   interface_name: Project Gutenberg
   note: Project Gutenberg.
   link: https://www.gutenberg.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187725775906381':
 - collection_name: The Vibe Archive
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/vibe
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187755478806381':
 - collection_name: 'Entertainment Industry Magazine Archive: Video Gaming'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/eima5/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187755481306381':
 - collection_name: 'Colonial Legacies: Empire & Commonwealth Periodicals'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/empire
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187779700706381':
 - collection_name: East View The Rafu Shimpo Digital Archive (DA-TRS)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/rafu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187779700806381':
 - collection_name: El Caribe Digital Archive
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/crl/elcaribe/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187779607606381':
 - collection_name: Post-Perestroika Newspapers
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/crl/ppn/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187779607906381':
 - collection_name: East View East African Newspapers Collection
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/crl/ean/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187779608206381':
 - collection_name: Cumhuriyet Digital Archive
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/cumhuriyet
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187779608306381':
 - collection_name: Imperial Russian Newspapers
   interface_name: East View
   note: East View. Open access for all users.
   link: https://www.eastview.com/resources/gpa/crl-irn/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784891906381':
 - collection_name: 'Archives of Sexuality and Gender Part 5: L''Enfer Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/10UG/AHSI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784892206381':
 - collection_name: 'Women’s Studies Archive: Rare Titles from the American Antiquarian Society, 1820-1922'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisCollection?userGroupName=umuser&inPS=true&mCode=10SX&prodId=WMNS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784892406381':
 - collection_name: 'Women’s Studies Archive: Voice and Vision'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisArchive?userGroupName=umuser&inPS=true&mCode=83U3&prodId=WMNS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784909406381':
 - collection_name: East View Russian Institute of Social Sciences Publications (UDB-INION)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/4550
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784912106381':
 - collection_name: Bates' Visual Guide to Physical Examination
   interface_name: Lippincott Williams & Wilkins
   note: 'Lippincott Williams & Wilkins. At login screen:  Click on "Library. Continue as anonymous library user". Authorized U-M users (+ guests in U-M Libraries)'
   link: https://clinicalcontext.lww.com/en/batesvisualguide
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784993406381':
 - collection_name: 'Women''s Studies Archive: Female Forerunners Worldwide'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisArchive?userGroupName=umuser&inPS=true&mCode=64SL&prodId=WMNS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784993506381':
 - collection_name: 'Southern Negro Youth Congress and the Communist Party: Papers of James and Esther Cooper Jackson'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4LKU/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784993606381':
 - collection_name: 'Indigenous Peoples of North America, Part II: The Indian Rights Association, 1882-1986'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisCollection?userGroupName=umuser&inPS=true&mCode=64G6&prodId=INDP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784993706381':
 - collection_name: 'Indian Trade in the Southeastern Spanish Borderlands: Papers of Panton, Leslie and Company'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisCollection?p=GDSC&u=umuser&mCode=4QOQ&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784996006381':
 - collection_name: 'Greensboro Massacre, 1979: Shootout between the American Nazis and the Communist Workers Party'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4wxe/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784996406381':
 - collection_name: Reports of the Immigrant Commission, 1907-1910
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60F3/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784996706381':
 - collection_name: Anglo-American Committee of Inquiry Palestine, 1944-1946
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4VZS/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784997506381':
 - collection_name: FBI File on Robert F. Kennedy
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisCollection?p=GDSC&u=umuser&mCode=60FC&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784998006381':
 - collection_name: FBI File on Joseph Kennedy
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisCollection?p=GDSC&u=umuser&mCode=60FB&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784998706381':
 - collection_name: FBI File on Albert Einstein
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://go.gale.com/ps/aboutThisCollection?p=GDSC&u=umuser&mCode=60FA&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784999106381':
 - collection_name: 'Associated Press Collections Online: U.S. City Bureaus Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/6PBF/APOA?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187784999206381':
 - collection_name: 'Associated Press Collections Online: News Features & Internal Communications'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/6OBR/APOA?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187725774206381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part O (2022)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187829285806381':
 - collection_name: Encyclopedia of Turkic languages and linguistics /
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brillonline.com/browse/encyclopedia-of-turkic-languages-and-linguistics-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187829286406381':
 - collection_name: Detroit News Historical and Current Collection
   interface_name: NewsBank
   note: NewsBank. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.lib.umich.edu/databases/record/45616
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187829299806381':
 - collection_name: Revolución y cultura, 1967-2009
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/revolucion-y-cultura
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187674514506381':
 - collection_name: Gu gong qi kan zhi shi ku =
   interface_name: ''
   note: Access to the National Palace Museum Journals online version restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/49154
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187674514406381':
 - collection_name: Zhuan ji wen xue =
   interface_name: ''
   note: Access to the Zhuanji wenxue Digital Archive online version restricted; authentication may be required.
   link: http://www.lib.umich.edu/database/link/49152
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187674514606381':
 - collection_name: Taiwan nichinichi shinpō.
   interface_name: ''
   note: ''
   link: http://www.lib.umich.edu/database/link/49151
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187829144206381':
 - collection_name: 'China and the Modern World: Records of the Maritime Customs Service of China, 1854-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/2YNC/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187829144406381':
 - collection_name: 'China and the Modern World: Missionary, Sinology, and Literary Periodicals, 1817-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/6SYG/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187829115806381':
 - collection_name: 'Archives of Sexuality and Gender: International Perspectives on LGBTQ Activism and Culture'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/83SL/AHSI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187833106806381':
 - collection_name: AES digital library
   interface_name: American Energy Society
   note: American Energy Society. American Energy Society requires umich.edu email and free personal account for access; authentication may be required.
   link: https://subscriptions.energysociety.org/umich43rg-256567.html
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188055987406381':
 - collection_name: Casalini Torrossa eBooks Institutional Catalogue
   interface_name: Casalini Torrossa
   note: Casalini Torrossa. Authorized U-M users (+ guests in U-M Libraries)
   link: http://digital.casalini.it/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187829177406381':
 - collection_name: Chinese and English Newspaper of Modern China - Comprehensive Collection (1874-1949).
   interface_name: ''
   note: Access to the National index to Chinese newspapers and periodicals online version restricted;  authentication may be required Access, limited to 5 concurrent user.
   link: http://www.lib.umich.edu/database/link/34793
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187840609906381':
 - collection_name: HathiTrust Digital Library Full View Worldwide
   interface_name: HathiTrust
   note: HathiTrust.
   link: http://www.hathitrust.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187840045306381':
 - collection_name: 'Interwar Culture Module II: the 1930s'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.interwarculture.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187845103206381':
 - collection_name: Foundations of Materials Science and Engineering
   interface_name: Scientific.net Journals
   note: Scientific.net Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.scientific.net/FoMSE
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187845104806381':
 - collection_name: East View Moscow News (DA-MN)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2990
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187845110906381':
 - collection_name: American Indian History Online
   interface_name: InfoBase Publishers, Inc.
   note: InfoBase Publishers, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://online.infobaselearning.com/Direct.aspx?aid=16234&pid=WE43
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187845803306381':
 - collection_name: 'Africa and the New Imperialism: European Borders on the African Continent, 1870-1914'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.africaandthenewimperialism.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187845798506381':
 - collection_name: 'Colonial Caribbean Module II: Colonial Government and Abolition, 1833-1849'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialcaribbean.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187845799206381':
 - collection_name: Big Ten Open Books Gender & Sexuality Studies Collection
   interface_name: University of Michigan Press
   note: University of Michigan Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www-fulcrum-org.proxy.lib.umich.edu/michigan?locale=en
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187847998306381':
 - collection_name: Art Institute of Chicago Digital Publications
   interface_name: Art Institute of Chicago
   note: Art Institute of Chicago.
   link: http://www.artic.edu/research/digital-publications/online-scholarly-catalogues/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187848208006381':
 - collection_name: Books of modern China
   interface_name: ''
   note: 5 concurrent user limit. Access to the National index to Chinese newspapers and periodicals online version restricted; Search for content; authentication may be required.
   link: http://www.lib.umich.edu/database/link/30872
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187851905506381':
 - collection_name: Codices Vossiani Latini Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/vossiani-latini
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187851905606381':
 - collection_name: U.S. Intelligence on the Middle East, 1945-2009
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/us-intelligence-on-the-middle-east
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187851905706381':
 - collection_name: Brill Online E-Books U.S. Intelligence On Asia, 1945-1991
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/us-intelligence-on-asia
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187851905806381':
 - collection_name: The Daily Worker Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/the-daily-worker-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187851906006381':
 - collection_name: Brill Online E-Books Hungarian Reformation Ebook Collection
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/hungarian-reformation
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187851911606381':
 - collection_name: Brill Online E-Books Hebrew And Judeo-Arabic Printing In Baghdad
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/hebrew-and-judeoarabic-printing-in-baghdad
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187852590406381':
 - collection_name: Japanese Periodicals Index (NDL 雑誌記事索引)
   interface_name: National Diet Library
   note: National Diet Library.
   link: https://ndlopac.ndl.go.jp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187857501206381':
 - collection_name: 'Political Extremism and Radicalism, Part 3: Communist and Socialist Movements'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/plex?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187857572006381':
 - collection_name: Brill Online E-Books Israel'S Messenger Online
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/israels-messenger
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187857326806381':
 - collection_name: University of Michigan Library Digital General Collection
   interface_name: University of Michigan Library
   note: University of Michigan Library. Open access for all users.
   link: https://quod.lib.umich.edu/g/genpub/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187857540806381':
 - collection_name: Brill Online E-Books Moses Maimonides, Unparalleled Editions Online
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/moses-maimonides-unparalleled-editions
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868494006381':
 - collection_name: SCOAP3 Ebook collection
   interface_name: SCOAP3 Journals
   note: SCOAP3 Journals. Authorized U-M users (+ guests in U-M Libraries)
   link: https://scoap3.org/scoap3-books/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187857539206381':
 - collection_name: Classic Brazilian Cinema Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/classic-brazilian-cinema-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187857539706381':
 - collection_name: Sephardic Editions, 1550-1820 Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/sephardic-editions-15501820
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868465306381':
 - collection_name: Muslims in Russia
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/muslims-in-russia
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868465406381':
 - collection_name: Mass Media in Russia, 1908-1918
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/mass-media-in-russia-19081918
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868465506381':
 - collection_name: Brill Online E-Books Imperial Russia'S Illustrated Press
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/imperial-russias-illustrated-press
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868465606381':
 - collection_name: Archives Of The Presbyterian Church Of Cuba
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/archives-of-the-presbyterian-church-of-cuba-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868465906381':
 - collection_name: Archives of the Church of Uganda Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/archives-of-the-church-of-uganda
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868466406381':
 - collection_name: Brill Online E-Books Russian-Ottoman Relations Part 4
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/russianottoman-relations-part-4
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868466506381':
 - collection_name: Brill Online E-Books Russian-Ottoman Relations Part 3
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/russianottoman-relations-part-3
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868466606381':
 - collection_name: Brill Online E-Books Russian-Ottoman Relations Part 2
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/russianottoman-relations-part-2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868466806381':
 - collection_name: Brill Online E-Books Russian-Ottoman Relations Part 1
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/russianottoman-relations-part-1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187868469706381':
 - collection_name: Early Western Korans
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/early-western-korans
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187872605106381':
 - collection_name: Pediatric care online
   interface_name: American Academy of Pediatrics
   note: American Academy of Pediatrics. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.pediatriccareonline.org/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187868449706381':
 - collection_name: 'ProQuest Historical Newspapers: Chicago Defender (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://about.proquest.com/en/products-services/pq-hist-news/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865862506381':
 - collection_name: Chronicle of Philanthropy
   interface_name: Chronicle of Philanthropy
   note: Chronicle of Philanthropy. Authorized U-M users (+ guests in U-M Libraries)
   link: http://philanthropy.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187877311106381':
 - collection_name: El Mundo Digital Archive
   interface_name: East View
   note: East View. Open access for all users.
   link: https://gpa.eastview.com/crl/elmundo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187883711906381':
 - collection_name: Human Resources Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=22h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187883712106381':
 - collection_name: PapersFirst
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: http://firstsearch.oclc.org/done=referer;dbname=PapersFirst;FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188116898906381':
 - collection_name: MoMA Exhibition Catalogs
   interface_name: MoMA
   note: MoMA. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.moma.org/calendar/exhibitions/history/?sort_date=&mde_type=Exhibition&location=both&begin_date=1929&end_date=now&q=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187884813606381':
 - collection_name: 'Broadcasting America: The Rise of Mass Media and Communications'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.broadcastingamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187885596106381':
 - collection_name: 'Feminae: Medieval Women and Gender Index'
   interface_name: University of Iowa
   note: University of Iowa.
   link: http://inpress.lib.uiowa.edu/feminae/Default.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187885599106381':
 - collection_name: South Asian Newspapers
   interface_name: East View
   note: East View. Open access for all users.
   link: https://www.eastview.com/resources/gpa/crl-san/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187885599206381':
 - collection_name: Southeast Asian Newspapers (Open Access)
   interface_name: East View
   note: East View. Open access for all users.
   link: https://gpa.eastview.com/crl/sean
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187888892906381':
 - collection_name: Cuban pre-revolutionary cinema /
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/db/cicu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187888893006381':
 - collection_name: Encyclopedia of Taiwan Studies Online
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/etso?rskey=QYSC7c
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187888893206381':
 - collection_name: 'Handbook of Formosan Languages Online: The Indigenous Languages of Taiwan'
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/hflo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187888893406381':
 - collection_name: Brill's encyclopedia of critical understanding in education.
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/db/ecue
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187888893706381':
 - collection_name: Oral poetry and narratives from Central Arabia /
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/db/opno
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187888894106381':
 - collection_name: Kitāb al-Ṭabaqāt al-kabīr /
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/db/tbqo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187891010206381':
 - collection_name: Access Water
   interface_name: Access Water
   note: Access Water. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.accesswater.org
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187893583306381':
 - collection_name: Faulkner Advisory for IT Studies (FAITS)
   interface_name: Faulkner
   note: Faulkner. Authorized U-M users (+ guests in U-M Libraries)
   link: https://faulkner.com/products/faits/?login
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187893588606381':
 - collection_name: Sage Campus Entire Platform
   interface_name: SAGE
   note: SAGE. Access requires personal registration. Authorized U-M users (+ guests in U-M Libraries)
   link: https://classroom.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: Sage Campus LOCAL
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: https://classroom.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187892677906381':
 - collection_name: Sociological Abstracts
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/sociologicalabstracts
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187903480606381':
 - collection_name: Dictionary of Irish Biography
   interface_name: Royal Irish Academy
   note: Royal Irish Academy.
   link: https://www.dib.ie/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187903480706381':
 - collection_name: Oxford English Dictionary
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oed.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187903807006381':
 - collection_name: English Poetry
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ep2?accountid=14667
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187903567606381':
 - collection_name: Periodicals Index Online
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/pio
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187903568706381':
 - collection_name: Brill's Africa Yearbook Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/serial/AYB
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187910212106381':
 - collection_name: JSTOR Path to Open
   interface_name: JSTOR
   note: JSTOR. Authorized U-M users (+ guests in U-M Libraries)
   link: https://about.jstor.org/path-to-open/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187910213906381':
 - collection_name: Oxford Dictionary of National Biography
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxforddnb.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187747855506381':
 - collection_name: OSTI Local
   interface_name: OSTI
   note: OSTI. Open access for all users.
   link: https://www.osti.gov/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187911404006381':
 - collection_name: Middle East and Islamic Studies E-Books Online, Collection 2024
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187911404506381':
 - collection_name: Classical Studies E-Books Online, Collection 2024
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187911412106381':
 - collection_name: Biblical Studies, Ancient Near East and Early Christianity E-Books Online, Collection 2024
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187911512106381':
 - collection_name: Queen Victoria's Journals
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/qvj
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187743802206381':
 - collection_name: Shiryō sanshū = Collected historical materials
   interface_name: NetAdvance
   note: NetAdvance. Authorized U-M users (+ guests in U-M Libraries)
   link: https://japanknowledge.com/lib/search/shiryosanshu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187919011206381':
 - collection_name: Royal Shakespeare Company Archives
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.royalshakespearecompanyarchives.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187919015206381':
 - collection_name: De Gruyter DG Plus DeG Package 2024 Part 1
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187920501706381':
 - collection_name: Luthers Werke
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/luther
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187920909606381':
 - collection_name: 'Bloomsbury Open Collections: African Studies and International Development (Backlist)'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Open access for all users.
   link: https://www.bloomsburycollections.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187922114506381':
 - collection_name: The W. B. Yeats Collection
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/yeatscollection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187923706106381':
 - collection_name: Environmental Science Index
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/esindex
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187924372906381':
 - collection_name: MRS Online Proceedings Library Archive
   interface_name: Cambridge University Press
   note: Cambridge University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www-cambridge-org.proxy.lib.umich.edu/core/journals/mrs-online-proceedings-library-archive/all-issues
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187925900406381':
 - collection_name: Drugs and Lactation Database (LactMed)
   interface_name: National Library of Medicine
   note: National Library of Medicine.
   link: https://www.ncbi.nlm.nih.gov/books/NBK501922/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187925906106381':
 - collection_name: Colonial Caribbean Module III
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialcaribbean.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187925906306381':
 - collection_name: 'Conflict in Indochina: Crisis and Upheaval, 1959-1964'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.conflictinindochina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187925868106381':
 - collection_name: 'Cambridge eBooks without Partner Presses: 2024 All eBooks'
   interface_name: Cambridge University Press
   note: Cambridge University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.cambridge.org/core/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187927104006381':
 - collection_name: LLMC-Digital
   interface_name: LLMC Digital
   note: LLMC Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://discover.llmc.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187926989306381':
 - collection_name: Complete Works of William Shakespeare
   interface_name: Massachusetts Institute of Technology
   note: Massachusetts Institute of Technology. Open access for all users.
   link: https://shakespeare.mit.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187931407606381':
 - collection_name: New Pauly Online
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brillonline.com/browse/brill-s-new-pauly
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187933302206381':
 - collection_name: Archiv für Diplomatik, Schriftgeschichte, Siegel- und Wappenkunde
   interface_name: ''
   note: ''
   link: https://www.vr-elibrary.de/doi/book/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187937408406381':
 - collection_name: CRL Open Access Monographs
   interface_name: Center for Research Libraries
   note: Center for Research Libraries.
   link: http://catalog.crl.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937411706381':
 - collection_name: Vandenhoeck & Ruprecht Open-Access-Downloads
   interface_name: Vandenhoeck & Ruprecht
   note: Vandenhoeck & Ruprecht.
   link: http://www.vr-elibrary.de
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937189006381':
 - collection_name: 'Gale Literature: Book Review Index'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BRIP?u=umuser&aty=ip
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937360506381':
 - collection_name: De Gruyter Yale University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937360606381':
 - collection_name: De Gruyter University of Toronto Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937360706381':
 - collection_name: De Gruyter University of Pennsylvania Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937361006381':
 - collection_name: De Gruyter Stanford University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937362106381':
 - collection_name: De Gruyter Rutgers University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937362206381':
 - collection_name: De Gruyter Princeton University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937362506381':
 - collection_name: De Gruyter Penn State University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937362706381':
 - collection_name: De Gruyter New York University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937363206381':
 - collection_name: De Gruyter Harvard University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937363306381':
 - collection_name: De Gruyter Fordham University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937363506381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937363606381':
 - collection_name: De Gruyter Cornell University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937363706381':
 - collection_name: De Gruyter Columbia University Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937363806381':
 - collection_name: De Gruyter University of Chicago Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187937364406381':
 - collection_name: De Gruyter Berghahn Books Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187947376406381':
 - collection_name: Encyclopaedia of Islam New Edition Online
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/eieo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187947203906381':
 - collection_name: Wiley Online Library Frontlist All English Titles 2024
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://onlinelibrary.wiley.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187947214006381':
 - collection_name: IOP eBooks 2024 Collection
   interface_name: Institute of Physics
   note: Institute of Physics. Authorized U-M users (+ guests in U-M Libraries)
   link: https://iopscience.iop.org/booklistinfo/home
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187947279606381':
 - collection_name: AP newsroom.
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&groupid=main&custid=s8873650&site=apnr&return=y
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187947286206381':
 - collection_name: Zhongguo ji ben gu ji ku.
   interface_name: ''
   note: 'Access to the Zhongguo ji ben gu ji ku restricted; Search for content; authentication may be required:  2 concurrent users.'
   link: https://apps.lib.umich.edu/database/link/49405
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187947159106381':
 - collection_name: JSTOR 19th Century British Pamphlets
   interface_name: JSTOR
   note: JSTOR. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jstor.org/site/19th-century-british-pamphlets/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187947159306381':
 - collection_name: 'World Heritage Sites: Africa'
   interface_name: JSTOR
   note: JSTOR. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jstor.org/site/heritage/africa/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187947159406381':
 - collection_name: 'Struggles for Freedom: Southern Africa'
   interface_name: JSTOR
   note: JSTOR. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jstor.org/site/struggles-for-freedom/southern-africa/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187947220106381':
 - collection_name: Gale Literary Criticism Online.
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: http://go.galegroup.com/ps/titleList.do?actionString=DO_FETCH_USER_EBOOKS&userGroupName=umuser&inPS=true&prodId=LCO
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187948380406381':
 - collection_name: Wiley-Blackwell Encyclopedia of Life Sciences
   interface_name: Wiley-Blackwell
   note: Wiley-Blackwell. Authorized U-M users (+ guests in U-M Libraries)
   link: https://onlinelibrary.wiley.com/doi/book/10.1002/047001590X
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187948393306381':
 - collection_name: United Nations Statistical Database
   interface_name: United Nations
   note: United Nations.
   link: https://unstats.un.org/UNSDWebsite/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187948402606381':
 - collection_name: University of Michigan Library ERRWPC
   interface_name: University of Michigan Library
   note: University of Michigan Library.
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187950696706381':
 - collection_name: Global Press Archive Donetsk and Luhansk Newspaper Collection
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/dnr/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187954390706381':
 - collection_name: Sovetskii Ekran Digital Archive
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/books/6070
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187959912906381':
 - collection_name: East View Far Eastern Affairs (DA-FEA)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/3530
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187964197306381':
 - collection_name: De Gruyter Vervuert Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187964169806381':
 - collection_name: Brill Online Chinese Reference Shelf
   interface_name: Brillonline
   note: Brillonline.
   link: https://chinesereferenceshelf.brillonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187964286206381':
 - collection_name: GCA Pubs and GIS Collection
   interface_name: ''
   note: Access to the East View online version restricted; authentication may be required.
   link: https://dlib.eastview.com/browse/udb/3870
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187979394906381':
 - collection_name: 'History commons : Weimar and Nazi Germany'
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://history-commons.net/modules/weimar-and-nazi-germany/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187979404506381':
 - collection_name: 'Africa Commons: Black South African Magazines'
   interface_name: Coherent Digital
   note: Coherent Digital. Some website features require a personal account. Authorized U-M users (+ guests in U-M Libraries)
   link: https://africacommons.net/modules/black-south-african-magazines
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'Africa Commons: Black South African Magazines'
   interface_name: Coherent Digital
   note: Coherent Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://africacommons.net/modules/black-south-african-magazines/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187979405206381':
 - collection_name: 'Africa Commons: Southern African Films and Documentaries'
   interface_name: Coherent Digital
   note: Coherent Digital. Some website features require a personal account. Authorized U-M users (+ guests in U-M Libraries)
   link: https://africacommons.net/modules/southern-african-films-and-documentaries/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187980196106381':
 - collection_name: Amnesty International Archives
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.amnestyinternationalhumanrights.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187980606706381':
 - collection_name: SAO/NASA Astrophysics Data System Abstract Service
   interface_name: NASA
   note: NASA.
   link: http://adsabs.harvard.edu/ads_abstracts.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187984903106381':
 - collection_name: Human Rights Documents Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/human-rights-documents-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187990277306381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part P (2023)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187990280806381':
 - collection_name: 'China and the Modern World: Hong Kong, Britain and China Part II, 1965-1993'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/53MG/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187990281006381':
 - collection_name: 'British Library Newspapers, Part VI: Ireland, 1783-1950'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/bncn?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187990283206381':
 - collection_name: De Gruyter Manchester University Press 2024 eBook-Package
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.degruyter.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187990283606381':
 - collection_name: De Gruyter Manchester University Press 2023 eBook-Package
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.degruyter.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187990369906381':
 - collection_name: Anthropology Plus
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=ant
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187990248706381':
 - collection_name: East View Global Census Archive
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gca.eastview.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187991697306381':
 - collection_name: 'Orlando: Women''s Writing in the British Isles from the Beginnings to the Present'
   interface_name: Cambridge University Press
   note: Cambridge University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99187991709806381':
 - collection_name: 'Associated Press Collections Online: Washington, D.C. Bureau Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/6PBG/APOA?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187992702406381':
 - collection_name: EBSCOHost Caribbean Search
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=b7h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187992471606381':
 - collection_name: 'ProQuest Historical Newspapers: Birmingham Post Herald'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpbirminghampostherald
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187992471806381':
 - collection_name: 'ProQuest Historical Newspapers: ABC'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpabc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187992472006381':
 - collection_name: Socialist and Radical Periodicals
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/socrad
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187992472506381':
 - collection_name: LGBT Magazine Archive Collection 2
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187996704406381':
 - collection_name: Treasury of Linguistic Maps Online
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997303506381':
 - collection_name: Digitalia Française
   interface_name: Digitalia
   note: Digitalia. Authorized U-M users (+ guests in U-M Libraries)
   link: https://livres.digitaliapublishing.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997304906381':
 - collection_name: 'Underground and Independent Comics, Comix, and Graphic Novels: Volume 3, The Modern Age'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/comx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997305006381':
 - collection_name: 'Contemporary Anthropology: Archaeological Fieldwork and Methods'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/cona
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997305106381':
 - collection_name: Projectr Collection - United States
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/the-projectr-collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997305206381':
 - collection_name: 'Forensic Nursing in Video: A Symptom Media Collection'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://video.alexanderstreet.com/channel/forensic-nursing-in-video-a-symptom-media-collection
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997305406381':
 - collection_name: 'Digital National Security Archive (DNSA): U.S. Foreign Policy in the Carter Years, 1977-1981: Highest-Level Memos to the President'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_62
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997305506381':
 - collection_name: 'Digital National Security Archive (DNSA): Targeting Iraq, Part II: War and Occupation, 2004-2011'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/dnsa_61
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997307206381':
 - collection_name: 'ProQuest Historical Newspapers: Philadelphia Tribune (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpphiladelphiatribune1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997307306381':
 - collection_name: 'ProQuest Historical Newspapers: Norfolk Journal and Guide (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpnorfolkjournalguide1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997307406381':
 - collection_name: 'ProQuest Historical Newspapers: New York Amsterdam News (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpnewamsterdamnews1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997307506381':
 - collection_name: 'ProQuest Historical Newspapers: Los Angeles Sentinel (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnplasentinel1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997307706381':
 - collection_name: 'ProQuest Historical Newspapers: Cleveland Call and Post (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpclevelandcallpost1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997308806381':
 - collection_name: 'ProQuest Historical Newspapers: The Baltimore Afro-American (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpbaltimoreafricanamerican1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997311606381':
 - collection_name: 'Oxford Bibliographies Online: Medieval Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780195396584
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997311906381':
 - collection_name: 'Oxford Bibliographies Online: Jewish Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199840731
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187998306006381':
 - collection_name: 'Oxford Bibliographies Online: Islamic Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780195390155
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997312506381':
 - collection_name: 'Oxford Bibliographies Online: Hinduism'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?sticky=true&module_1=obo-9780195399318&q=
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997312906381':
 - collection_name: 'Oxford Bibliographies Online : Chinese Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780199920082
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997313306381':
 - collection_name: 'Oxford Bibliographies Online : Childhood Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://oxfordbibliographies.com/browse?module_0=obo-9780199791231
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187998310106381':
 - collection_name: 'Oxford Bibliographies Online: Buddhism'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780195393521
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997314006381':
 - collection_name: 'Oxford Bibliographies Online: Biblical Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780195393361
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997315006381':
 - collection_name: 'Oxford Bibliographies Online : Anthropology'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780199766567
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187998110706381':
 - collection_name: T&T Clark Encyclopedia of Second Temple Judaism
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.theologyandreligiononline.com/second-temple-judaism
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188000313706381':
 - collection_name: Building Types Online
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/view/db/bdt
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188000787006381':
 - collection_name: Dictionary of Old English Web Corpus
   interface_name: University of Toronto
   note: University of Toronto. Authorized U-M users (+ guests in U-M Libraries)
   link: https://corpus.doe.utoronto.ca/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188002011706381':
 - collection_name: Abstracts in Social Gerontology
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=27h
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188002314906381':
 - collection_name: 'Africa Commons: The Hilary Ngweno Archive'
   interface_name: Coherent Digital
   note: Coherent Digital. Some website features require a personal account. Authorized U-M users (+ guests in U-M Libraries)
   link: https://africacommons.net/modules/the-hilary-ngweno-archive/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188004203806381':
 - collection_name: Benezit Dictionary of Artists
   interface_name: Oxford University Press
   note: Oxford University Press. 5 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordartonline.com/benezit
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188004391206381':
 - collection_name: 'Bloomsbury Open Collections: African Studies and International Development (Frontlist)'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Open access for all users.
   link: https://www.bloomsburycollections.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188020309706381':
 - collection_name: Women’s Voices and Life Writing, 1600-1968
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.womensvoicesandlifewriting.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188020309806381':
 - collection_name: Apartheid South Africa, 1981-1988
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.amdigital.co.uk/collection/apartheid-south-africa-1948-1980
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188020309906381':
 - collection_name: 'British Newsreels, 1911-1930: Culture and Society on Film'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.britishnewsreels.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990134629440106381':
 - collection_name: Collection of Korean Geography, Customs and History DB
   interface_name: Media Korean Studies DB
   note: Media Korean Studies DB. Authorized U-M users (+ guests in U-M Libraries)
   link: http://db.mkstudy.com/en/mksdb/korean-geography/description/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188025992206381':
 - collection_name: 'China and the Modern World: Records of Shanghai and the International Settlement, 1836-1955'
   interface_name: GaleGroup
   note: GaleGroup. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/53SX/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188025948306381':
 - collection_name: 'Conflict in Indochina: Escalation, Reunification and Withdrawal, 1965-1979'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.amdigital.co.uk/collection/conflict-in-indochina-foreign-office-files-for-vietnam-laos-and-cambodia
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 - collection_name: 'Conflict in Indochina: Escalation, Reunification and Withdrawal, 1965-1979'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188025950206381':
 - collection_name: 'The Transformation of Shopping: Department Stores, Social Change and Consumerism, 1830-1994'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.thetransformationofshopping.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188025950306381':
 - collection_name: 'East India Company: Module 6, Board of Commissioners: Establishment of the Board'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188862098306381':
 - collection_name: Records of Early English Drama
   interface_name: University of Toronto
   note: University of Toronto. Open access for all users.
   link: https://reed.utoronto.ca/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187262553806381':
 - collection_name: Annals of the New York Academy of Sciences
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://nyaspubs.onlinelibrary.wiley.com/journal/17496632
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188025920906381':
 - collection_name: 1980s Culture and Society
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.1980scultureandsociety.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990124842630106381':
 - collection_name: 'Music Online: Listening'
   interface_name: Alexander Street Press
   note: Alexander Street Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/musp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188031597106381':
 - collection_name: 'Black Drama: Third Edition'
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/bld3
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188031814106381':
 - collection_name: WhoPlus
   interface_name: WhoPlus
   note: WhoPlus. 10 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.nichigai.co.jp/database/who-plus.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997310906381':
 - collection_name: 'Oxford Bibliographies Online: Urban Studies'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780190922481
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997311206381':
 - collection_name: 'Oxford Bibliographies Online: Philosophy'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordbibliographies.com/browse?module_0=obo-9780195396577
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187997311406381':
 - collection_name: 'Oxford Bibliographies Online: Music'
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.oxfordbibliographies.com/browse?module_0=obo-9780199757824
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990166668920106381':
 - collection_name: Human Rights Watch reports
   interface_name: Human Rights Watch
   note: Human Rights Watch.
   link: https://www.hrw.org/publications
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040405006381':
 - collection_name: Artstor Open Access on JSTOR
   interface_name: JSTOR
   note: JSTOR. Some website features require a personal account.
   link: https://www.jstor.org/site/artstor/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040405106381':
 - collection_name: Artstor
   interface_name: JSTOR
   note: JSTOR. Some website features require a personal account. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.jstor.org/site/artstor/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040366106381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2022
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040366306381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2021
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040366406381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2020
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040366606381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2019
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040366806381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2018
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040367306381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2017
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040367406381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2016
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040367506381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2014-2015
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyter.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040367606381':
 - collection_name: De Gruyter University of Texas Press eBook-Package Backlist 2000-2013
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040369306381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2023
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040370506381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040372606381':
 - collection_name: De Gruyter University of Hawaii Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040525906381':
 - collection_name: Church Missionary Society Archives
   interface_name: Adam Matthew Publications Ltd
   note: Adam Matthew Publications Ltd. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.amscholar.amdigital.co.uk/CMS
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040530606381':
 - collection_name: East India Company, Module V
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastindiacompany.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040538306381':
 - collection_name: CiNii Complete
   interface_name: CiNii Complete
   note: CiNii Complete.
   link: http://ci.nii.ac.jp/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040339106381':
 - collection_name: HeinOnline Index to Foreign Legal Periodicals (IFLP)
   interface_name: Hein Online
   note: Hein Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://heinonline.org/hol/index?collection=iflp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040345106381':
 - collection_name: Hindi Cinema
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.hindicinema.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441306381':
 - collection_name: Russia Presidential Election, 2012
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2416
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441406381':
 - collection_name: Russia State Duma Election, 2011
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2417
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441506381':
 - collection_name: Russia Presidential Election, 2008
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/3712
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441606381':
 - collection_name: Russia State Duma Election, 2007
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/3711
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441706381':
 - collection_name: Russia State Duma Election, 1999
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/3710
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441806381':
 - collection_name: Soviet Coup Attempt, 1991
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/4010
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040441906381':
 - collection_name: Russia in Transition, 1990s
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/4090
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040442006381':
 - collection_name: Russia Referendum, 1993
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/4110
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040442106381':
 - collection_name: Russia's Constitutional Crisis, 1993
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/4050
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040442206381':
 - collection_name: Russia State Duma Election, 1993
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/3850
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188040443406381':
 - collection_name: Kyrgyzstan Parliamentary Election, 2015
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2710
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188044607006381':
 - collection_name: MagazinePlus
   interface_name: Nichigai Associates, Inc.
   note: Nichigai Associates, Inc. 10 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: https://web.nichigai.jp/nos/nweb/magazine/search/?lang=0&smode=1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188044610406381':
 - collection_name: 'Sezgin Online II: the Frankfurt Volumes'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brillonline.com/browse/sezgin-online-2
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188045704706381':
 - collection_name: International Law - Book Archive pre-2000
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/package/9789004537545
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188045704806381':
 - collection_name: Human Rights and Humanitarian Law - Book Archive pre-2000
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/package/9789004537552
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188045704906381':
 - collection_name: vLex America Latina
   interface_name: vLex
   note: vLex. Authorized U-M users (+ guests in U-M Libraries)
   link: https://explore.vlex.com/%23/by-product/en/latin_america/latin_america
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188045705106381':
 - collection_name: ProQuest Legislative Insight 2024-forward
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://li.proquest.com/legislativeinsight
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188045706206381':
 - collection_name: ProQuest Indian Claims Insight
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://indianclaims.proquest.com/indianclaims/search/basic/IciBasicSearch
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188045708006381':
 - collection_name: EBSCOhost Art Full Text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/direct.asp?db=aft
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188045708106381':
 - collection_name: Retrospective Index to Music Periodicals (RIPM)
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rip
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188049205506381':
 - collection_name: New Testament Abstracts
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=rvh
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188049205606381':
 - collection_name: EBSCOhost Business Abstracts with Full Text
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=bft
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188049999806381':
 - collection_name: Music Research Annual
   interface_name: Music Research Annual
   note: Music Research Annual. Open access for all users.
   link: https://musicresearchannual.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188051269206381':
 - collection_name: IARC Monographs on the Evaluation of Carcinogenic Risks to Humans
   interface_name: International Agency for Research on Cancer (IARC)
   note: International Agency for Research on Cancer (IARC)
   link: https://monographs.iarc.who.int/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055762306381':
 - collection_name: Ansel Adams's Photographs of Japanese-American Internment at Manzanar
   interface_name: Library of Congress
   note: Library of Congress.
   link: http://www.loc.gov/collections/ansel-adams-manzanar/about-this-collection/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055762406381':
 - collection_name: 'Fine Prints: Japanese, pre-1915'
   interface_name: Library of Congress
   note: Library of Congress.
   link: https://www.loc.gov/collections/japanese-fine-prints-pre-1915/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055971306381':
 - collection_name: Arcanum newspapers.
   interface_name: Arcanum Newspapers
   note: Arcanum Newspapers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://adt.arcanum.com/en/discover/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188056077206381':
 - collection_name: Motif-Index of Folk Literature
   interface_name: Intelex_Past_Masters
   note: Intelex_Past_Masters. Authorized U-M users (+ guests in U-M Libraries)
   link: http://pm.nlx.com/xtf/view?docId=motif/motif.00.xml
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055730106381':
 - collection_name: West Academic Casebooks Archive
   interface_name: Hein Online
   note: Hein Online.
   link: https://heinonline.org/HOL/Index?collection=wacas
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055730206381':
 - collection_name: HeinOnline U.S. State Commitments with Foreign Governments
   interface_name: Hein Online
   note: Hein Online.
   link: https://heinonline.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055751706381':
 - collection_name: Japanese Historical Maps
   interface_name: Cartography Associates
   note: Cartography Associates.
   link: http://japanmaps.davidrumsey.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188055751806381':
 - collection_name: Japanese Rare Book Digital Collection
   interface_name: Library of Congress
   note: Library of Congress.
   link: https://www.loc.gov/collections/japanese-rare-books/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188073788506381':
 - collection_name: medici.tv.
   interface_name: medici.tv
   note: medici.tv. Authorized U-M users (+ guests in U-M Libraries)
   link: https://edu.medici.tv/en
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188074990506381':
 - collection_name: MEDLINE (Ovid)
   interface_name: Ovid
   note: Ovid. Authorized U-M users (+ guests in U-M Libraries)
   link: http://ovidsp.ovid.com/ovidweb.cgi?T=JS&NEWS=n&CSC=Y&PAGE=main&D=mesz
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188074990606381':
 - collection_name: Joanna Briggs Institute EBP database
   interface_name: Ovid
   note: Ovid. Authorized U-M users (+ guests in U-M Libraries)
   link: http://ovidsp.ovid.com/ovidweb.cgi?T=JS&NEWS=n&CSC=Y&PAGE=main&D=jbi&MODE=easy
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188870031306381':
 - collection_name: Torrossa Open
   interface_name: Casalini Libri
   note: Casalini Libri. Open access for all users.
   link: https://oa.torrossa.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075236806381':
 - collection_name: Sage CQ Press Supreme Court Yearbook
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: http://library.cqpress.com/scyb
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188075250706381':
 - collection_name: 'History Vault: Women''s Studies Manuscript Collections from the Schlesinger Library: Voting Rights, National Politics, and Reproductive Rights'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvwomensschles
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075250806381':
 - collection_name: 'History Vault: Black Freedom Struggle in the 20th Century: Organizational Records and Personal Papers, Part 1'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvblackfreedomorg1
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075250906381':
 - collection_name: 'History Vault: Black Freedom Struggle in the 20th Century: Organizational Records and Personal Papers, Part 2'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvblackfreedomorg2
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075251006381':
 - collection_name: 'History Vault: Black Freedom Struggle in the 20th Century: Federal Government Records, Supplement'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvblackfreedomfedsup
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075251106381':
 - collection_name: 'History Vault: Black Freedom Struggle in the 20th Century: Federal Government Records'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvblackfreedomfed1
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075251306381':
 - collection_name: 'History Vault: Office of Strategic Services (OSS)-State Department Intelligence and Research Reports, 1941-1961'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvossstatedeptintel
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188075251406381':
 - collection_name: 'History Vault: Workers, Labor Unions, and the American Left in the 20th Century: Federal Records'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvworkerslabor
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188075251706381':
 - collection_name: Web of Science KCI - Korean Journal Database
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/kjd/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188075252006381':
 - collection_name: Web of Science Grants Index
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/grants/united-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188075252206381':
 - collection_name: Web of Science Derwent Innovations Index.
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/diidw/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075252306381':
 - collection_name: Web of Science Data Citation Index
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/drci/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188075252406381':
 - collection_name: Web of Science Chinese Science Citation Database
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/cscd/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075252606381':
 - collection_name: Web of Science Biosis Citation Index
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/bci/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188075252706381':
 - collection_name: Web of Science Core Collection
   interface_name: Clarivate
   note: Clarivate. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.webofscience.com/wos/woscc/basic-search
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188073985306381':
 - collection_name: MEDLINE (OCLC FirstSearch)
   interface_name: OCLC
   note: OCLC. Authorized U-M users (+ guests in U-M Libraries)
   link: https://firstsearch.oclc.org/dbname=MEDLINE;FSIP
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990043368930106381':
 - collection_name: 'The United States and its Territories, 1870 - 1925: The Age of Imperialism'
   interface_name: University of Michigan Library
   note: University of Michigan Library.
   link: https://quod.lib.umich.edu/p/philamer/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188074958906381':
 - collection_name: 'Oxford Scholarship - Oxford University Press: Law'
   interface_name: Oxford Scholarship Online
   note: Oxford Scholarship Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordscholarship.com/browse?t=oso:law
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252730906381':
 - collection_name: SAGE CQ Press Supreme Court Collection
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: http://library.cqpress.com/scc/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252731606381':
 - collection_name: SAGE CQ Press Voting and Elections Collection
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: http://library.cqpress.com/elections/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092388506381':
 - collection_name: SAGE CQ Press Almanac
   interface_name: SAGE
   note: SAGE. Authorized U-M users (+ guests in U-M Libraries)
   link: http://library.cqpress.com/cqalmanac
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092390606381':
 - collection_name: 'History Vault: FBI Confidential Files and Radical Politics in the U.S., 1945-1972'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvfbiconffiles
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092390706381':
 - collection_name: 'History Vault: African American Police League Records, 1961-1988'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvaapoliceleague
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092390806381':
 - collection_name: 'History Vault: Women at Work during World War II: Rosie the Riveter and the Women''s Army Corps'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvrosieriveter
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092390906381':
 - collection_name: 'History Vault: American Indians and the American West, 1809-1971'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvamerindianswest
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391006381':
 - collection_name: 'History Vault: Law and Society since the Civil War: American Legal Manuscripts from the Harvard Law School Library'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvlawandsocietyharv
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391106381':
 - collection_name: 'History Vault: Confidential U.S. State Department Central Files, 1960-1969: Africa and Middle East'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvstatecentralaf_me
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092391206381':
 - collection_name: 'History Vault: Confidential U.S. State Department Central Files, 1960-1969: Europe and Latin America'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvstatecentraleur_latam
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391306381':
 - collection_name: 'History Vault: Confidential U.S. State Department Central Files, 1960-1969: Asia'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvstatecentral_asia
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092391406381':
 - collection_name: 'History Vault: Thomas A. Edison Papers'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvthomasedison
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391506381':
 - collection_name: 'History Vault: Vietnam War and American Foreign Policy, 1960-1975'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvvietnamwar
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391606381':
 - collection_name: 'History Vault: American Politics and Society from Kennedy to Watergate, 1960-1975'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvkennedywatergate
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391706381':
 - collection_name: 'History Vault: Slavery and the Law'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvslaveryandlaw
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391806381':
 - collection_name: 'History Vault: NAACP Papers: Branch Department, Branch Files, and Youth Department Files'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnaacp6
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092391906381':
 - collection_name: 'History Vault: NAACP Papers: Special Subjects'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnaacp5
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092392006381':
 - collection_name: 'History Vault: Struggle for Women''s Rights: Organizational Records, 1880-1990'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvwomensrights1
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092392206381':
 - collection_name: Ethnicity & Culture Magazine Archive
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/ecma
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092393806381':
 - collection_name: 'History Vault: Southern Life and African American History, 1775-1915, Plantation Records, Part 1'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvplantations1
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092393906381':
 - collection_name: 'History Vault: Southern Life and African American History, 1775-1915, Plantation Records, Part 2'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvplantations2
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092394106381':
 - collection_name: 'History Vault: NAACP Papers: The NAACP''s Major Campaigns - Legal Department Files'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnaacp4
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092394206381':
 - collection_name: 'History Vault: NAACP Papers: The NAACP''s Major Campaigns - Scottsboro, Anti-Lynching, Criminal Justice, Peonage, Labor, and Segregation and Discrimination Complaints and Responses'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnaacp3
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092394306381':
 - collection_name: 'History Vault: NAACP Papers: The NAACP''s Major Campaigns - Education, Voting, Housing, Employment, Armed Forces'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnaacp2
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092394406381':
 - collection_name: 'History Vault: NAACP Papers: Board of Directors, Annual Conferences, Major Speeches, and National Staff Files'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnaacp1
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092394606381':
 - collection_name: 'History Vault: Immigration: Records of the INS, 1880-1930'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvimmigration
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188092394706381':
 - collection_name: 'History Vault: Japanese American Incarceration: Records of the War Relocation Authority, 1942-1946'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvjapaneseincarceration
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092394806381':
 - collection_name: 'History Vault: Students for a Democratic Society, Vietnam Veterans Against the War, and the anti-Vietnam War Movement'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvsdsvvaw
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092394906381':
 - collection_name: 'History Vault: Labor Unions in the U.S., 1862-1974: Knights of Labor, AFL, CIO, and AFL-CIO'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvlaborunions
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092395306381':
 - collection_name: 'History Vault: Margaret Sanger Papers: Smith College Collections and Collected Documents'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvmsangerpapers
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092395406381':
 - collection_name: 'History Vault: Creation of Israel: British Foreign Office Correspondence on Palestine and Transjordan, 1940-1948'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvcreationisrael
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092395506381':
 - collection_name: 'History Vault: Socialist Party of America Papers'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvsocialistpartyofamerica
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092395606381':
 - collection_name: 'History Vault: Southern Life and African American History, 1775-1915, Plantation Records, Part 3'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvplantations3
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092411506381':
 - collection_name: Open Knowledge Repository
   interface_name: World Bank
   note: World Bank. Open access for all users.
   link: https://openknowledge.worldbank.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092366906381':
 - collection_name: 'History Vault: Planning for the Post-World War II World, State Department Records of Harley A. Notter, 1939-1945'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvnotter
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188092331806381':
 - collection_name: 'Mexico in History: Colonialism to Revolution'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.mexicoinhistory.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188103008506381':
 - collection_name: 'Associated Press Collections Online: European Bureaus Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/8NCS/APOA?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188103008606381':
 - collection_name: 'Associated Press Collections Online: The Middle East Bureaus Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/8NCT/APOA?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188103008906381':
 - collection_name: 'Nineteenth Century Collections Online: Women: Transnational Networks'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/5YJA/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188103009006381':
 - collection_name: 'Gale Nineteenth Century Collections Online: Mapping the World: Maps and Travel Literature'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/6RWA/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187632013906381':
 - collection_name: 'Nineteenth Century Collections Online: Asia and the West: Diplomacy and Cultural Exchange'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/5630/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575546306381':
 - collection_name: 'Gale Nineteenth Century Collections Online: European Literature, 1790-1840: The Corvey Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/5632/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575546406381':
 - collection_name: 'Gale Nineteenth Century Collections Online: British Theatre, Music, and Literature: High and Popular Culture'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/5631/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187575546606381':
 - collection_name: 'Gale Nineteenth Century Collections Online: British Politics and Society'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/5629/NCCO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107711606381':
 - collection_name: 'History Vault: Slavery, the Slave Trade, and Law and Order in 19th Century America'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvslavery19thcentury
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107711706381':
 - collection_name: 'History Vault: Reconstruction and Military Government after the Civil War, 1865-1877'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvreconstruction
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107711806381':
 - collection_name: 'History Vault: Latino Civil Rights during the Carter Administration'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvlatinocivilcarter
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107711906381':
 - collection_name: 'History Vault: Joint Chiefs of Staff in the Early Cold War, 1946-1960'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvjointchiefsstaff
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107712006381':
 - collection_name: 'History Vault: Workers, Labor, and Race: Records of the Fair Employment Practices Committee, 1941-1946'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvfepc1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107712106381':
 - collection_name: 'History Vault: American Jewish Congress Records: Administrative and Executive Committee, Governing Council, National Conventions, and Executive Director Files'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvamjewishcongexecutive
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107712206381':
 - collection_name: 'History Vault: Reverend J. H. Jackson and the National Baptist Convention, 1900-1990'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvrevjacksonnbc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107712406381':
 - collection_name: 'History Vault: Americans for Democratic Action Records, 1932-1999'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvamericansdem
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188107712606381':
 - collection_name: 'History Vault: Slavery in Antebellum Southern Industries'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hvslaveryindustries
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188110314606381':
 - collection_name: Naxos Video Library (NVL) US
   interface_name: Naxos Music Library (NML)
   note: Naxos Music Library (NML) Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.NaxosVideoLibrary.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188110314706381':
 - collection_name: Naxos Music Library (NML) US
   interface_name: Naxos Music Library (NML)
   note: Naxos Music Library (NML) Authorized U-M users (+ guests in U-M Libraries)
   link: https://umich.nml3.naxosmusiclibrary.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188114877806381':
 - collection_name: Neighborhood Change Database [NCDB] Tract Data
   interface_name: GeoLytics, Inc.
   note: GeoLytics, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://demographics.geolytics.com/NCDB/PreLoginForm.aspx
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188114878206381':
 - collection_name: Parker Library on the Web
   interface_name: Stanford University
   note: Stanford University. Open access for all users.
   link: https://parker.stanford.edu/parker/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188114878306381':
 - collection_name: Drugs at FDA
   interface_name: FDA/Center for Drug Evaluation and Research
   note: FDA/Center for Drug Evaluation and Research.
   link: https://www.accessdata.fda.gov/scripts/cder/daf/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188116889206381':
 - collection_name: 'ProQuest Historical Newspapers: St. Louis American'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpstlouisamerican
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188116898406381':
 - collection_name: 'ProQuest Congressional Hearings Digital Collection: Part Q (2024)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188116899006381':
 - collection_name: 'Wiley Digital Archives: Environmental Science and History'
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.wileydigitalarchives.com/env
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188119415106381':
 - collection_name: 'The Olympic Movement: Sport, Global Politics and Identity'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.theolympicmovement.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188119415206381':
 - collection_name: 'American Committee on Africa: Liberation Movements, Solidarity and Activism'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.americancommitteeonafrica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188121300306381':
 - collection_name: Periodicals of the Baltics, Belarus, Moldova, and Ukraine (UDB-EUR)
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2190
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188122733806381':
 - collection_name: 'Palestine: The Legal Background'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/palestine-the-legal-background
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188122733906381':
 - collection_name: 'Palestine: The British Mandate, 1917–1948'
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/browse/palestine-the-british-mandate
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188122734506381':
 - collection_name: Encyclopedia of Greek Language and Linguistics Online
   interface_name: ''
   note: Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/gllo?rskey=8fvobu&contents=mrw-title-toc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188122742706381':
 - collection_name: 2023 Lived Places Publishing Library Collection
   interface_name: 2023 Lived Places Publishing Library Collection
   note: 2023 Lived Places Publishing Library Collection. Authorized U-M users (+ guests in U-M Libraries)
   link: https://livedplacespublishing.com/page/collections
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188125543106381':
 - collection_name: GIDEON Ebooks 2024
   interface_name: GIDEON Informatics, Inc.
   note: GIDEON Informatics, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.gideononline.com/ebooks/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188125850206381':
 - collection_name: Google LIFE Photo Archive
   interface_name: Google.com
   note: Google.com. Open access for all users.
   link: http://images.google.com/hosted/life
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188126528106381':
 - collection_name: 'We Were Prepared for the Possibility of Death: Freedom Riders in the South, 1961'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4hlv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188126528206381':
 - collection_name: Edition.fi
   interface_name: HULib_OA
   note: HULib_OA. Open access for all users.
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188126432906381':
 - collection_name: Classical Studies E-Books Online, Collection 2025
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.brill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188126433006381':
 - collection_name: Biblical Studies, Ancient Near East and Early Christianity E-Books Online, Collection 2025
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.brill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188126433106381':
 - collection_name: Middle East and Islamic Studies E-Books Online, Collection 2025
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.brill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188126433206381':
 - collection_name: Pandemics, Society, and Public Health, 1517-1925
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/125/pandemics-society-and-public-health-1517-1925
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188126290806381':
 - collection_name: Dolley Madison Digital Edition
   interface_name: University of Virginia
   note: University of Virginia. Authorized U-M users (+ guests in U-M Libraries)
   link: http://rotunda.upress.virginia.edu/dmde
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188149117706381':
 - collection_name: 'ProQuest Historical Newspapers: Boston Globe (All Years)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/hnpnewyorkbostonglobe1
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403862506381':
 - collection_name: Mobilizing East Asia Online
   interface_name: Brill
   note: Brill. Authorized U-M users (+ guests in U-M Libraries)
   link: http://primarysources.brillonline.com/browse/mobilizing-east-asia-online
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403863906381':
 - collection_name: De Gruyter Yale University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864006381':
 - collection_name: De Gruyter Vervuert Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864106381':
 - collection_name: De Gruyter University of Toronto Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864206381':
 - collection_name: De Gruyter University of Texas Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864306381':
 - collection_name: De Gruyter University of Pennsylvania Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864406381':
 - collection_name: De Gruyter University of Hawaii Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864506381':
 - collection_name: De Gruyter University of Chicago Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864606381':
 - collection_name: De Gruyter University of California Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864706381':
 - collection_name: De Gruyter Stanford University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864806381':
 - collection_name: De Gruyter Rutgers University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403864906381':
 - collection_name: De Gruyter Princeton University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865006381':
 - collection_name: De Gruyter Penn State University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865106381':
 - collection_name: De Gruyter New York University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865206381':
 - collection_name: De Gruyter Manchester University Press 2025 eBook-Package
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865306381':
 - collection_name: De Gruyter Harvard University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865506381':
 - collection_name: De Gruyter Fordham University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865606381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188403865706381':
 - collection_name: De Gruyter DG Plus DeG Package 2025 Part 1
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865806381':
 - collection_name: De Gruyter Cornell University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403865906381':
 - collection_name: De Gruyter Columbia University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403866006381':
 - collection_name: De Gruyter Berghahn Books Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403867406381':
 - collection_name: 'Trade in Early Modern London: Livery Company Records, 1450-1750'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.tradeinearlymodernlondon.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403869106381':
 - collection_name: 'ProQuest Historical Newspapers: Vancouver Sun'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/hnpvancouversun
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188403875006381':
 - collection_name: 'BAR: British Archaeological Reports International Series 2023'
   interface_name: University of Michigan
   note: University of Michigan. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.fulcrum.org/barpublishing
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188840726206381':
 - collection_name: 'Bloomsbury Cultural History: 2023-24 Collection'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.bloomsbury.com/uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843124706381':
 - collection_name: 'Ecuador: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOL/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843124906381':
 - collection_name: 'Colombia: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9iok/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843125006381':
 - collection_name: 'Chile: Records of the U.S. Department of State; 1930-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOG/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843125106381':
 - collection_name: 'Brazil: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOJ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843125206381':
 - collection_name: 'Bolivia: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOI/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843125306381':
 - collection_name: 'Peru: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOO/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843125406381':
 - collection_name: 'Argentina: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOH/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843195406381':
 - collection_name: 'FBI File: Watergate'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9ioz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843195606381':
 - collection_name: FBI File on Owen Lattimore
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRX/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843195706381':
 - collection_name: FBI File on Nelson Rockefeller
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRD/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843195806381':
 - collection_name: FBI File on John L. Lewis
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRJ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843195906381':
 - collection_name: FBI File on Harry Dexter White
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2yra/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843196006381':
 - collection_name: FBI File on Eleanor Roosevelt
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ysb/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843196106381':
 - collection_name: FBI File on America First Committee
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YSA/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843196606381':
 - collection_name: 'FBI File: House Committee on Un-American Activities (HUAC)'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9iow/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843196906381':
 - collection_name: 'FBI File: American POWs/MIAs in Southeast Asia'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13se/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843197106381':
 - collection_name: 'FBI File: Alger Hiss/Whittaker Chambers'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9iox/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843197406381':
 - collection_name: 'FBI File: Huey Long'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SD/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843198006381':
 - collection_name: 'FBI File: Assassination of Martin Luther King, Jr.'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9ioy/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843214006381':
 - collection_name: Election of 1948
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2zdr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843214606381':
 - collection_name: 'Egypt: Records of the U.S. Department of State; 1853-1962'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9BRB/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843517906381':
 - collection_name: ProQuest Congressional Record Permanent Digital Collection Part A (Includes Predecessors) (1789-1997)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188843518006381':
 - collection_name: ProQuest Congressional Record Permanent Digital Collection Part B (1998-2001)
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://congressional.proquest.com/congressional/search/advanced/advanced
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845730906381':
 - collection_name: 'Liberia and the U.S.: Nation-Building in Africa, 1918-1935'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9BQW/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731006381':
 - collection_name: 'Lebanon; Palestine; Syria; Trans-Jordan: Records of the U.S. Department of State; 1836-1944'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9BRD/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731106381':
 - collection_name: 'Jewish Question: Records from the Berlin Document Center'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5dst/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731206381':
 - collection_name: 'Japanese American Internment: Records of the Franklin D. Roosevelt Library'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RZ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731306381':
 - collection_name: 'Japan: U.S. Naval Technical Mission; 1945-1946'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RQ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731406381':
 - collection_name: Japan-U.S. Economic Relations Group Records; 1979-1981
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RR/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731506381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Political Relations, 1945-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RW/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731606381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Political Relations; 1940-1944'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RV/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731706381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Political Relations; 1930-1939'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RU/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731806381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Commercial Relations; 1950-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RT/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845731906381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Commercial Relations; 1910-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RS/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845732006381':
 - collection_name: 'Japan: Records of the U.S. Department of State, 1950-1959'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9INX/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845732206381':
 - collection_name: 'Japan and Korea: Summation of Nonmilitary Activities, 1945-1948'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RP/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845732306381':
 - collection_name: 'Iraq: Records of the U.S. Department of State, 1888-1944'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9BRC/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845732406381':
 - collection_name: 'Iran (Persia): Records of the U.S. Department of State; 1883-1959'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9bqy/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845732506381':
 - collection_name: International War on Drugs
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2zwj/gdsc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845732606381':
 - collection_name: International Climatic Changes and Global Warming
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2zwh/gdsc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845933506381':
 - collection_name: Western Books on Southeast Asia
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/035p/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845933606381':
 - collection_name: 'U.S. and Castro''s Cuba, 1950–1970: The Paterson Collection'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRI/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845933706381':
 - collection_name: 'Turkey: Records of the U.S. Department of State; 1802-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9BRA/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845933806381':
 - collection_name: 'Spiro T. Agnew Case: The Investigative and Legal Documents'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2yrw/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845933906381':
 - collection_name: 'Records of the U.S. State Department: Briefing Books Relating to the Situation in Vietnam; 1961-1966; From the Records of the Bureau of Far Eastern Affairs'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5rae/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845934006381':
 - collection_name: Records of the Department of State Relating to Internal Affairs, Ethiopia, 1945-1963
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sq/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845934106381':
 - collection_name: 'Panama: Records of the U.S. Department of State; 1950-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9ION/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845934206381':
 - collection_name: Palestine Statehood Committee Records, 1939-1949
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845934306381':
 - collection_name: 'Pacifism, Disarmament and International Relations - Archives of War Resisters'' International: Minutes, Reports, and Publications, 1921-1974'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2zwa/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845934406381':
 - collection_name: 'Pacifism, Disarmament and International Relations - Archives of the Fellowship of Reconciliation: Minute Books and Committee Papers, 1915-1960'
   interface_name: Gale
   note: Gale.
   link: https://link.gale.com/apps/collection/2zwb/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845935206381':
 - collection_name: 'Nicaragua: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOM/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845935606381':
 - collection_name: 'Libya: Records of the U.S. Department of State; 1796-1885'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9BRF/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845695106381':
 - collection_name: Eastview Belarus e-books approval plan
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/910
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845614106381':
 - collection_name: Copper Data Center Database
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.proquest.com/copper
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188845654306381':
 - collection_name: ASM Medical Materials Database
   interface_name: ASM International
   note: ASM International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://matdata.asminternational.org/mmd/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849301906381':
 - collection_name: Rise and Fall of Senator Joseph R. McCarthy
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZDQ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302006381':
 - collection_name: 'South Vietnam: Records of the Office of the Defense Attache; 1973-1975'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOS/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302106381':
 - collection_name: The Global War on Terrorism
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZWF/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302206381':
 - collection_name: The Global Financial and Economic Crisis
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZWG/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302306381':
 - collection_name: Sukarno and the Army-PKI Rivalry in the Years of Living Dangerously, 1960-1963
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6TWE/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302406381':
 - collection_name: 'The Legal Battle for Civil Rights in Alabama: Vernon Z. Crawford Records, 1958-1978 Civil Rights Cases and Selections from the Blacksher, Menefee & Stein Records'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZWC/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302506381':
 - collection_name: The Minority Voter, Election of 1936 and the Good Neighbor League
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3CCW/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302606381':
 - collection_name: 'The War on Poverty and the Office of Economic Opportunity: Administration of Antipoverty Programs and Civil Rights, 1964-1967'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRU/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302706381':
 - collection_name: U.S. Operations Mission in Iran, 1950-1961
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRT/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302806381':
 - collection_name: 'U.S. Military Activities and Civil Rights: The Military Response to the March on Washington, 1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRR/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849302906381':
 - collection_name: 'U.S. Military Activities and Civil Rights: The Little Rock Integration Crisis, 1957-1958'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRS/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303006381':
 - collection_name: 'U.S. Military Activities and Civil Rights: Integration of the University of Mississippi and the Use of Military Force, 1961-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2YRQ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303106381':
 - collection_name: 'War on Poverty: Office of Civil Rights; 1965-1968'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/94D1/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303206381':
 - collection_name: 'War on Poverty Community Profiles: Western States'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/94Q1/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303306381':
 - collection_name: 'War on Poverty Community Profiles: Texas'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/94PZ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303406381':
 - collection_name: 'War on Poverty Community Profiles: Southern States'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/94PV/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303506381':
 - collection_name: 'War on Poverty Community Profiles: Northeastern States'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/94G2/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303606381':
 - collection_name: 'War on Poverty Community Profiles: Midwestern States'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/94PX/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303706381':
 - collection_name: 'Union Label and the Needle Trades: Records of the United Garment Workers of America'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6JIJ/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849303806381':
 - collection_name: 'U.S. Relations and Policies in Southeast Asia, 1944-1958: Records of the Office of Southeast Asian Affairs'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5541/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188849308906381':
 - collection_name: 'Cambridge eBooks without Partner Presses: 2025 All eBooks'
   interface_name: Cambridge University Press
   note: Cambridge University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.cambridge.org/core/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188851811806381':
 - collection_name: Encyclopedia of Medicine in the Greco-Roman World /
   interface_name: Brill Online reference works
   note: Brill Online reference works. Authorized U-M users (+ guests in U-M Libraries)
   link: https://referenceworks.brill.com/display/db/emgo
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188851608106381':
 - collection_name: ASM Handbooks Online
   interface_name: ASM International
   note: ASM International. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dl.asminternational.org/handbooks
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188853010906381':
 - collection_name: GIDEON - Global Infectious Disease and Epidemiology Network
   interface_name: GIDEON Informatics, Inc.
   note: GIDEON Informatics, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.gideononline.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188858108806381':
 - collection_name: EZB-DIGI-00331 DigiZeitschriften
   interface_name: DigiZeitschriften
   note: DigiZeitschriften. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.digizeitschriften.de/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188860111806381':
 - collection_name: Wiley Online Library Frontlist All English Titles 2025
   interface_name: Wiley Online Library
   note: Wiley Online Library. Authorized U-M users (+ guests in U-M Libraries)
   link: https://onlinelibrary.wiley.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188860906706381':
 - collection_name: 2024 Lived Places Publishing Library Collection
   interface_name: 2023 Lived Places Publishing Library Collection
   note: 2023 Lived Places Publishing Library Collection. Authorized U-M users (+ guests in U-M Libraries)
   link: https://livedplacespublishing.com/page/collections
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188862208706381':
 - collection_name: 'British Literary Manuscripts Online: 1600-1900'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BLMO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188862208806381':
 - collection_name: 'British Literary Manuscripts Online: Medieval and renaissance'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BLMO?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865743206381':
 - collection_name: 'Bloomsbury Drama Online: Critical Studies and Performance Practice - Annual Update 2024'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.dramaonlinelibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865743306381':
 - collection_name: 'Bloomsbury Drama Online: Focal Press Theatre Books'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.dramaonlinelibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865743406381':
 - collection_name: 'Bloomsbury Drama Online: Theatre and Performance History Collection'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.dramaonlinelibrary.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865658506381':
 - collection_name: Universitäts- und Landesbibliothek Sachsen-Anhalt (ULB)
   interface_name: Martin-Luther-Universität Halle-Wittenberg
   note: Martin-Luther-Universität Halle-Wittenberg. Open access for all users.
   link: https://bibliothek.uni-halle.de/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865860006381':
 - collection_name: HeinOnline Federal Register Library
   interface_name: Hein Online
   note: Hein Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://heinonline.org/HOL/Index?collection=fedreg
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188865640206381':
 - collection_name: UN iLibrary Journals
   interface_name: United Nations
   note: United Nations.
   link: https://digitallibrary.un.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496865606381':
 - collection_name: Foreign Office Files for China 1967-80, The Cultural Revolution
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefileschina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496866006381':
 - collection_name: Foreign Office Files for China 1938-48, Open Door, Japanese war and the seeds of communist victory
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefileschina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496870106381':
 - collection_name: 'Colonial America Module V: Growth, Trade and Development'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.colonialamerica.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187729305606381':
 - collection_name: Gilded Age and Progressive Era
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.gildedage.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187729305506381':
 - collection_name: 'Mass Observation Project: Module II 1990s'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.massobservationproject.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517658006381':
 - collection_name: 'Mass Observation Project: Module I 1980s'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.massobservationproject.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496866206381':
 - collection_name: Foreign Office Files for China 1919-29, Kuomintang, CCP and the Third International
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefileschina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187524486406381':
 - collection_name: 'Service Newspapers of World War 2: Module II'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.servicenewspapers.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496864506381':
 - collection_name: Foreign Office Files for South East Asia, 1963-1966, Cold War in the Pacific, Trade Relations, and the Post-Independence Period, 1963-1966
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefilessoutheastasia.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187496865906381':
 - collection_name: Foreign Office Files for China 1949-56, The Communist revolution
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.foreignofficefileschina.amdigital.co.uk
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187517665106381':
 - collection_name: 'Medical Services and Warfare: Module II 1928-1949'
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.medicalservicesandwarfare.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188867934506381':
 - collection_name: Brillonline Open Access Books
   interface_name: Brillonline
   note: Brillonline. Download of full PDF book may be required to view Open Access content.
   link: https://brill.com/browse?access=open&et=book&level=parent&pageSize=10&sort=datedescending
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188870148906381':
 - collection_name: Materials Science Index
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.proquest.com/msindex
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188870059806381':
 - collection_name: IBZ - Internationale Bibliographie der Geistes- und Sozialwissenschaftlichen Zeitschriftenliteratur
   interface_name: De Gruyter Saur
   note: De Gruyter Saur. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com/database/ibz/html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188870059906381':
 - collection_name: Encyclopedia of the Bible and Its Reception
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188870060006381':
 - collection_name: Encyclopedia of Jewish-Christian Relations Online
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878077006381':
 - collection_name: 'State Papers Online: Colonial - Asia, Part III :'
   interface_name: ''
   note: ''
   link: https://link.gale.com/apps/spoc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878405406381':
 - collection_name: State of Michigan Government Documents
   interface_name: State of Michigan
   note: State of Michigan. Open access for all users.
   link: https://www.michigan.gov/som
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878191406381':
 - collection_name: ASM Alloy Digest
   interface_name: ASM Alloy Digest
   note: ASM Alloy Digest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dl.asminternational.org/alloy-digest
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878183906381':
 - collection_name: MiVideo U-M Licensed Videos
   interface_name: MiVideo
   note: MiVideo. Authorized U-M users (+ guests in U-M Libraries)
   link: https://um-licensed-videos.mivideo.it.umich.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188878144706381':
 - collection_name: 'Associated Press Collections Online: The Washington D.C. Bureau Collection, Part II (1915-1930)'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/8NCU/APOA?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188888848006381':
 - collection_name: BrillOnline Dictionaries
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dictionaries.brillonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188890065806381':
 - collection_name: 'BAR: British Archaeological Reports International Series 2025'
   interface_name: University of Michigan Press
   note: University of Michigan Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://umich.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188891169006381':
 - collection_name: UMPEBC University of Michigan Press eBooks 2025
   interface_name: University of Michigan Press
   note: University of Michigan Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://umich.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252532706381':
 - collection_name: 'Arte Público Hispanic Historical Collection: Series 2'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=h6b
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252532806381':
 - collection_name: 'Arte Público Hispanic Historical Collection: Series 1'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=h6a
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898724806381':
 - collection_name: 'China: Records of the U.S. Department of State; 1945-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RO/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898724906381':
 - collection_name: 'China: Records of the U.S. Department of State; 1940-1944'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9INW/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898725106381':
 - collection_name: 'China: Records of the U.S. Department of State; 1930-1939: Part 2'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RN/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898725306381':
 - collection_name: 'China: Records of the U.S. Department of State; 1930-1939: Part 1'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13RM/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898725406381':
 - collection_name: Carter Administration and Foreign Affairs
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SL/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898725506381':
 - collection_name: 'Cambodia: Records of the U.S. Department of State; 1960-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9IOQ/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898725606381':
 - collection_name: 'Bulgaria: Records of the U.S. Department of State Relating to Internal Affairs; 1950-1954'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95K6/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898725706381':
 - collection_name: 'Bulgaria: Records of the U.S. Department of State Relating to Internal Affairs; 1945-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95K4/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898726006381':
 - collection_name: 'British Foreign Office: United States Correspondence; 1946-1948'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SR/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898726306381':
 - collection_name: 'British Foreign Office: United States Correspondence; 1944-1945'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SQ/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898726506381':
 - collection_name: 'British Foreign Office: United States Correspondence; 1941-1943'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SP/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898726606381':
 - collection_name: 'British Foreign Office: United States Correspondence; 1938-1940'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SO/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898726706381':
 - collection_name: 'British Foreign Office: United States Correspondence; 1935-1937'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SN/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898726806381':
 - collection_name: 'British Foreign Office: United States Correspondence; 1930-1934'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13SM/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898727006381':
 - collection_name: 'Archives of the Campaign for Nuclear Disarmament: Pamphlets and Serials, 1985-1990 and Bruce Kent''s Speeches and Articles, 1981-1989'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZVZ/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898727106381':
 - collection_name: 'Archives of the Campaign for Nuclear Disarmament: Annual Reports, Minutes and other Records, pamphlets and serial items, 1981-1985'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZVY/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898727206381':
 - collection_name: 'Archives of the Campaign for Nuclear Disarmament: Annual Reports, Minutes and other Records, 1973-1980, and pamphlets and serial items, 1958-1980'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZVX/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898728906381':
 - collection_name: 'Archives of the Campaign for Nuclear Disarmament: Annual Reports, Minutes and other Records, 1958-1972'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2ZDU/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898729506381':
 - collection_name: 'Albania: Records of the U.S. Department of State, 1945-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9brj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898798306381':
 - collection_name: 'Archives of Sexuality & Gender Part VI: Community and Identity in North America'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/54PA/AHSI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898928406381':
 - collection_name: 'Reporting on Africa: From Apartheid to Pan-Africanism, 1949-1995'
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/40/reporting-on-africa-from-apartheid-to-pan-africanism-1949-1995
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990123646220106381':
 - collection_name: De Krant van Toen
   interface_name: De Krant van Toen
   note: De Krant van Toen. Open access for all users.
   link: https://www.dekrantvantoen.nl
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990165159370106381':
 - collection_name: Xiao bao
   interface_name: ''
   note: Access limited to 5 concurrent user; Access to the National index to Chinese newspapers and periodicals online version restricted; Search for content; authentication may be required.
   link: http://www.lib.umich.edu/database/link/45883
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878077306381':
 - collection_name: 'State Papers Online Colonial: Asia, Part II: Singapore, East Malaysia, and Brunei'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/spoc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898792106381':
 - collection_name: Communism, Culture and Society in the 20th Century
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/105/communism-culture-and-society-in-the-20th-century
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898792206381':
 - collection_name: Communism and Popular Culture in the 20th Century
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/103/communism-and-popular-culture-in-the-20th-century
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898792306381':
 - collection_name: Gender, Feminism, and the British Left, 1944-1991
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/94/gender-feminism-and-the-british-left-1944-1991
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898792406381':
 - collection_name: Debate and Division on the British Left, 1917-1964
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/95/debate-and-division-on-the-british-left-1917-1964
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898792506381':
 - collection_name: 'Trade Unions in Crisis: the 1961 ETU Ballot-Rigging Scandal'
   interface_name: Microform Academic Publishers
   note: Microform Academic Publishers. Authorized U-M users (+ guests in U-M Libraries)
   link: https://microform.digital/boa/collections/96/trade-unions-in-crisis-the-1961-etu-ballot-rigging-scandal
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878074206381':
 - collection_name: Inquisitions - Manuscripts of the Spanish, Portuguese and French Inquisitions in the British Library, London
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sp/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898947306381':
 - collection_name: 'German Folklore and Popular Culture: Das Kloster, Scheible'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4lko/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073506381':
 - collection_name: 'Food History: Printed and Manuscript Recipe Books; 1669-1990'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4yog/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878076006381':
 - collection_name: 'Environmental History: Conservation and Public Policy in America, 1870-1980'
   interface_name: GaleGroup
   note: GaleGroup. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/ENVH?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073206381':
 - collection_name: East Germany from Stalinization to the New Economic Policy, 1950-1963
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fgs/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878074106381':
 - collection_name: 'Counterattack Project: The FBI Files'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sk/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878076506381':
 - collection_name: 'China and the Modern World: Imperial China and the West Part II, 1865-1905'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/67XB/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878076606381':
 - collection_name: 'China and the Modern World: Imperial China and the West Part I, 1815-1881'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/archive/10TB/CFER?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898947406381':
 - collection_name: 'China and the Modern World: Diplomacy and Political Secrets, 1860-1950'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/cfer?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878074006381':
 - collection_name: 'Blacks in the U.S. Armed Forces: Basic Documents, 1639-1973'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/117M/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073906381':
 - collection_name: 'Black Nationalism and the Revolutionary Action Movement: The Papers of Muhammad Ahmad (Max Stanford)'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4jyg/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878074906381':
 - collection_name: 'Administrative Histories of U.S. Civilian Agencies: Korean War'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54t0/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898947506381':
 - collection_name: Seventeenth and Eighteenth Century Nichols Newspapers Collection
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/nicn?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898959906381':
 - collection_name: Nixon Administration and Foreign Affairs
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9iov/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898960106381':
 - collection_name: The Earl George Macartney Collection
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/005u/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898960406381':
 - collection_name: 'Laos: Records of the U.S. Department of State; 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9ior/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898960606381':
 - collection_name: Johnson Administration and Foreign Affairs
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9iou/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878075006381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Internal Affairs; 1955-1959'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95jo/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878075206381':
 - collection_name: 'Japan: Records of the U.S. Department of State Relating to Internal Affairs; 1950-1954'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95jm/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966006381':
 - collection_name: 'Hungary: Records of the U.S. Department of State; 1945-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966106381':
 - collection_name: 'Greece: Records of the U.S. Department of State, 1950-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqg/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966206381':
 - collection_name: 'George H. W. Bush and Foreign Affairs: Fall of the Berlin Wall and the Reunification of Germany'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13sj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966306381':
 - collection_name: 'George H. W. Bush and Foreign Affairs: Bosnia and the Situation in the Former Yugoslavia'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13si/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966506381':
 - collection_name: Ford Administration and Foreign Affairs
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9iot/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966606381':
 - collection_name: 'Finland: Records of the U.S. Department of State Relating to Internal Affairs; 1960-Jan. 1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95k2/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966706381':
 - collection_name: 'Finland: Records of the U.S. Department of State Relating to Internal Affairs; 1955-1959'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95k0/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966806381':
 - collection_name: 'Finland: Records of the U.S. Department of State Relating to Internal Affairs; 1950-1954'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95jy/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188898966906381':
 - collection_name: 'Finland: Records of the U.S. Department of State Relating to Internal Affairs; 1945-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/95jw/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073606381':
 - collection_name: 'World Communism: Pamphlets from McMaster University'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/8mhr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878074306381':
 - collection_name: U.S. Relations with Panama and Operation Just Cause
   interface_name: U.S. Relations with Panama and Operation Just Cause
   note: U.S. Relations with Panama and Operation Just Cause. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60GF/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878074406381':
 - collection_name: 'U.S. Army Center of Military History Historical Manuscripts Collection: The Korean War'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60ge/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878075906381':
 - collection_name: The Mail on Sunday Historical Archive,1982-2011
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/msha?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073706381':
 - collection_name: 'Socialist Party of the United States: Personal Papers of Darlington Hoopes, 1917-1968'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/117L/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909425306381':
 - collection_name: 'Shanghai International Settlement: Shanghai Municipal Council Reports, Minutes of Ratepayers Meetings, and Shanghai Volunteer Corps'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60gk/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909425406381':
 - collection_name: 'Refugees, Relief, and Resettlement: Forced Migration and World War II'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/rrrw?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073006381':
 - collection_name: 'Records of the U.S. State Department: East Germany and Berlin; Political and Governmental Affairs; February 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5rpx/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909432406381':
 - collection_name: Brill's Companions to Classical Studies Online VII
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://brill.com/display/package/9789004687356
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909709806381':
 - collection_name: Illiustrirovannaia Rossiia Archive
   interface_name: East View Information Services
   note: East View Information Services. Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/3671
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909932106381':
 - collection_name: Sage Knowledge EBA KNCCBR25 Complete Books and Reference Collection
   interface_name: SAGE
   note: SAGE.
   link: https://sk.sagepub.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909825206381':
 - collection_name: 'Public Housing, Racial Policies, and Civil Rights: The Intergroup Relations Branch of the Federal Public Housing Administration, 1936-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/2yrv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909825606381':
 - collection_name: 'Poland: Records of the U.S. Department of State; 1945-1963'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tql/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188909825806381':
 - collection_name: 'Pakistan from Crown Rule to Republic: Records of the U.S. Department of State, 1945-1949'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9brg/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911516906381':
 - collection_name: 'Franklin D. Roosevelt - ''The Great Communicator''; The Master Speech Files; 1898; 1910-1945: Series 1 - Franklin D. Roosevelt''s Political Ascension'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4wmd/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911517106381':
 - collection_name: Ford Administration and Human Rights
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/117T/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911518006381':
 - collection_name: FBI Manuals of Instruction; Investigative Procedures; and Guidelines; 1927-1978
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5drq/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911518106381':
 - collection_name: FBI Filing and Records Procedures
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5dfv/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911518406381':
 - collection_name: Essays by German Officers and Officials; 1939-1945
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5dfu/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911518606381':
 - collection_name: 'Dissent in Poland: The Opposition Archives'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sm/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911518706381':
 - collection_name: 'Dissent in Poland: The Eastern Archives'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sl/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911518806381':
 - collection_name: 'Dissent in Poland: Birth of a Social Movement'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/54sn/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911519506381':
 - collection_name: 'Czechoslovakia Crisis; 1968 : The State Department''s Crisis Files'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4wft/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911519806381':
 - collection_name: Civil Rights and Social Activism in the South - James A. Dombrowski and the Southern Conference Educational Fund
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4vnr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911520306381':
 - collection_name: British Political Opinion Polls and Social Surveys, 1960-1988
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/60GI/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911520706381':
 - collection_name: Army Quarterly and Defence Journal; 1920-1983
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4wfs/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911520906381':
 - collection_name: 'Archives of the Work Projects Administration and Predecessors; 1933-1943: Final Reports of the State Program; 1943'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4vns/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911521006381':
 - collection_name: Amateur Newspapers from the American Antiquarian Society (Part 2)
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3LNK/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911522506381':
 - collection_name: 'Patriotes aux Armes!: The Underground Resistance in France, Belgium, Holland, and Italy, 1939-1945'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4rjm/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188878073806381':
 - collection_name: 'Grassroots Civil Rights & Social Activism: FBI Files on Benjamin J. Davis, Jr'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6NGI/GDSC?u=umuser&sid=bookmark-GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911525906381':
 - collection_name: Economy and War in the Third Reich
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3fis/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188911526606381':
 - collection_name: Amerasia Affair, China and Postwar Anti‐Communist Fervor
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4egp/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188914523406381':
 - collection_name: 'Bloomsbury Cultural History: Annual Update 2025'
   interface_name: Bloomsbury Publishing Plc
   note: Bloomsbury Publishing Plc. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.bloomsburyculturalhistory.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188914322406381':
 - collection_name: 'Entertainment Industry Magazine Archive: Rock, Folk and Hip-hop'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/?selectids=1010092,1010094,1010093
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187725774406381':
 - collection_name: Queer Pasts (Text)
   interface_name: Alexander Street
   note: Alexander Street. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.alexanderstreet.com/qupa
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188914428006381':
 - collection_name: PressReader United States - Academic
   interface_name: PressReader
   note: PressReader. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.pressreader.com
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188914622006381':
 - collection_name: 'Entertainment Industry Magazine Archive: Cinema, Film and Television (Part 2)'
   interface_name: ProQuest
   note: ProQuest. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.proquest.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188914399406381':
 - collection_name: Spanish Civil War
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4xoa/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187599273306381':
 - collection_name: 'Making of the Modern World, Part III: 1890-1945'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/mome?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917912606381':
 - collection_name: Merriam-Webster Unabridged
   interface_name: Merriam-Webster, Inc.
   note: Merriam-Webster, Inc. Access to the Authorized U-M users (+ guests in U-M Libraries)
   link: https://dictionary.eb.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918004806381':
 - collection_name: 'Turkey, Greece, and the Balkan States: Records of the U.S. Department of State, 1930-1944'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/9bqz/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918005406381':
 - collection_name: Shakespeare Collection (Archives Unbound)
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3ehi/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918015906381':
 - collection_name: Papers of Sir Austen Chamberlain
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6ngg/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918016006381':
 - collection_name: Papers of Neville Chamberlain
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6ngf/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918016306381':
 - collection_name: Papers of Joseph Chamberlain
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6ngh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918016706381':
 - collection_name: 'Minutemen: Rise of the Militia Movement in America, 1963-1969'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4QOH/GDSC?u=umuser&sid=GDSC
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918019406381':
 - collection_name: Indian Army and Colonial Warfare on the Frontiers of India, 1914-1920
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6nxy/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918019606381':
 - collection_name: The George W. Ball Papers
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4vzr/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918026306381':
 - collection_name: 'Socialism and National Unity in Yugoslavia, 1945-63: Records of the U.S. State Department Classified Files'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/3tqi/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918026406381':
 - collection_name: 'Records of the U.S. State Department: The French Colonies in Sub-Saharan Africa; 1945-1963: Internal and Foreign Affairs'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5syu/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918026506381':
 - collection_name: 'Records of the U.S. State Department: Nigeria; Political and Governmental Affairs; February 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5srj/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918026606381':
 - collection_name: 'Records of the U.S. State Department: Ghana; Political Relations and Governmental Affairs; February 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5rte/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918026806381':
 - collection_name: 'Records of the U.S. State Department: Congo; Political and Governmental Affairs; February 1963-1966'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/5rcm/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918027206381':
 - collection_name: 'Post-War Europe: Refugees, Exile and Resettlement 1945-1950 (DFG Nationallizenzen)'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/6aco/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918031106381':
 - collection_name: National Security and FBI Surveillance Enemy Aliens
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4wxc/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918032206381':
 - collection_name: Home Intelligence Reports; 1940-1944
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/4vtq/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918115806381':
 - collection_name: Milne Open Textbooks (Open SUNY Textbooks)
   interface_name: Milne Library Publishing at SUNY Geneseo
   note: Milne Library Publishing at SUNY Geneseo. Open access for all users.
   link: ''
   status: Not Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252631106381':
 - collection_name: ANU Open Research Repository
   interface_name: Australian National University Library
   note: Australian National University Library. Open access for all users.
   link: https://openresearch-repository.anu.edu.au/home
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917889106381':
 - collection_name: Times Comprehensive Atlas of the World Digital Archiv
   interface_name: ''
   note: Access to the Authorized U-M users (+ guests in U-M Libraries)
   link: https://dlib.eastview.com/browse/udb/2790
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918064106381':
 - collection_name: Corpus de la première littérature francophone de l'Afrique noire
   interface_name: Classiques Garnier Numerique
   note: Classiques Garnier Numerique. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.classiques-garnier.com/numerique-bases/index.php?module=App&action=FrameMain&colname=ColClf
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918065006381':
 - collection_name: 'Brill Palestine: The British Mandate, 1917-1948'
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918065106381':
 - collection_name: 'Brill Palestine: The Legal Background'
   interface_name: Brillonline
   note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
   link: https://primarysources.brillonline.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188924078706381':
 - collection_name: El Comercio Digital Archive
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://gpa.eastview.com/ec/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188924078806381':
 - collection_name: Holos Ukrainy Digital Archive
   interface_name: ''
   note: Access to the Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastview.com/resources/gpa/holos-ukrainy/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188924079006381':
 - collection_name: Baghdad observer digital archive.
   interface_name: ''
   note: Access to the Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.eastview.com/resources/gpa/baghdad-observer/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188924085206381':
 - collection_name: 'Wiley Digital Archives: Royal College of Physicians Part I'
   interface_name: Wiley Online Library
   note: Wiley Online Library. Access to the Authorized U-M users (+ guests in U-M Libraries)
   link: https://app.wileydigitalarchives.com/rcp
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917852806381':
 - collection_name: Digital South Asia Library
   interface_name: Center for Research Libraries
   note: Center for Research Libraries. Open access for all users.
   link: http://dsal.uchicago.edu/index.html
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917854806381':
 - collection_name: ARTFL Project
   interface_name: University of Chicago Library
   note: University of Chicago Library. Authorized U-M users (+ guests in U-M Libraries)
   link: http://artfl-project.uchicago.edu
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917855906381':
 - collection_name: ProQuest Government Documents
   interface_name: ''
   note: ''
   link: https://www.proquest.com/index
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918041706381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2000-2013
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918041806381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2014-2016
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918041906381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2016
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. The University of Hawaiʻi Press was founded in 1947, publishing research in all disciplines of the humanities and natural and social sciences in the regions of Asia and Pacific. The Press's core mission revolves around the acquisition of books and journals that support new scholarship, enhance student success, and nurture Native Hawaiian ways of learning. UH Press has an especially distinguished list in Asian studies and is recognized as a leader in the fields of Buddhist studies and Southeast Asian studies.
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918042006381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2017
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918042106381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2018
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918042206381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2019
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918042406381':
 - collection_name: De Gruyter University of Hawaii Press eBook Package 2020
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918042506381':
 - collection_name: De Gruyter University of Hawaii Press Complete eBook-Package 2021
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918042706381':
 - collection_name: De Gruyter University of Hawaii Press Complete eBook-Package 2022
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043106381':
 - collection_name: De Gruyter Edinburgh University Press Backlist eBook-Package 2013-2000
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043206381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2014-2015
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043306381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2016
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043406381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2017
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043506381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2018
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043606381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2019
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043706381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2020
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188918043806381':
 - collection_name: De Gruyter Edinburgh University Press Complete eBook-Package 2021
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188917749206381':
 - collection_name: ARTFL-FRANTEXT
   interface_name: University of Chicago Press
   note: University of Chicago Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://artfl-permalink.uchicago.edu/frantext
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188924073106381':
 - collection_name: Springer Nature - Academic Journals on nature.com All
   interface_name: SpringerNature
   note: SpringerNature.
   link: https://www.springernature.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188927944606381':
 - collection_name: 'History of Disabilities: Disabilities in Society, Seventeenth to Twentieth Century'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/HODI?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188928033806381':
 - collection_name: 'George H. W. Bush and Foreign Affairs: The Moscow Summit and the Dissolution of the USSR'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13sh/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188928034006381':
 - collection_name: 'George H. W. Bush and Foreign Affairs: The Middle East Peace Conference in Madrid'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/collection/13sk/gdsc?u=umuser&sid=gdsc
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188928035206381':
 - collection_name: 'Refugees, Relief and Resettlement part 2: The Cold War'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/RRRW?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188928040306381':
 - collection_name: A Global History of Epidemics, 1800-1970
   interface_name: AM (Adam Matthew)
   note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.globalhistoryofepidemics.amdigital.co.uk/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930352306381':
 - collection_name: Oxford Scholarly Editions Online Latin Prose
   interface_name: Oxford Scholarly Editions Online
   note: Oxford Scholarly Editions Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordscholarlyeditions.com/nos
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930352506381':
 - collection_name: Oxford Scholarly Editions Online Latin Poetry
   interface_name: Oxford Scholarly Editions Online
   note: Oxford Scholarly Editions Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://oxfordscholarlyeditions.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930352706381':
 - collection_name: Oxford Scholarly Editions Online Herodotus
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://global.oup.com/academic/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930352906381':
 - collection_name: Oxford Scholarly Editions Online - Thucydides
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordscholarlyeditions.com/view/10.1093/oseo/person.00039625
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930353006381':
 - collection_name: Oxford Scholarly Editions Online Latin Drama
   interface_name: Oxford Scholarly Editions Online
   note: Oxford Scholarly Editions Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordscholarlyeditions.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930353206381':
 - collection_name: Oxford Scholarly Editions Online Greek Poetry
   interface_name: Oxford Scholarly Editions Online
   note: Oxford Scholarly Editions Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordscholarlyeditions.com/page/18/title-lists%23greek-poetry
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930353406381':
 - collection_name: Oxford Scholarly Editions Online Greek Comedy
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordhandbooks.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930353606381':
 - collection_name: Oxford Scholarly Editions Online Latin History
   interface_name: Oxford Scholarly Editions Online
   note: Oxford Scholarly Editions Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://oxfordscholarlyeditions.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930353706381':
 - collection_name: Oxford Scholarly Editions Online Greek Tragedy
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordhandbooks.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930354406381':
 - collection_name: Oxford Scholarly Editions Online Greek Prose
   interface_name: Oxford Scholarly Editions Online
   note: Oxford Scholarly Editions Online. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.oxfordscholarlyeditions.com/page/18/title-lists%23greek-prose
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930354806381':
 - collection_name: Oxford Scholarly Editions Online Homer
   interface_name: Oxford University Press
   note: Oxford University Press. Authorized U-M users (+ guests in U-M Libraries)
   link: https://corp.oup.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930730706381':
 - collection_name: Sabinet African Journals Core Collection
   interface_name: Sabinet
   note: Sabinet. Authorized U-M users (+ guests in U-M Libraries)
   link: http://reference.sabinet.co.za
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188930735706381':
 - collection_name: 'DIMACS Series in Discrete Mathematics and Theoretical Computer Science: Backfile'
   interface_name: American Mathematical Society
   note: American Mathematical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ams.org/publications/ebooks/dimacs-coll
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188930737806381':
 - collection_name: 'Contemporary Mathematics: 2025'
   interface_name: American Mathematical Society
   note: American Mathematical Society. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.ams.org/publications/ebooks/conm-coll
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188932359206381':
 - collection_name: 'Power to the People: Counterculture, Social Movements, and the Alternative Press, Nineteenth to Twenty-First Century'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/Popc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187542824106381':
 - collection_name: 'Brazilian and Portuguese History and Culture: Oliveira Lima Library, Pamphlets'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/bphc?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188933246906381':
 - collection_name: 'Brazilian and Portuguese History and Culture: Oliveira Lima Library, Monographs'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/BPHC?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188933247006381':
 - collection_name: 'Public Health Archives: Public Health in Modern America, 1890-1970'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/phia?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252572106381':
 - collection_name: 'Slavery and Anti-Slavery, Part IV: The Age of Emancipation'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/sas?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99187252576106381':
 - collection_name: 'Slavery and Anti-Slavery, Part III: The Institution of Slavery'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/sas?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188933249006381':
 - collection_name: 'Slavery and Anti-Slavery, Part II: Slave Trade in the Atlantic World'
   interface_name: Gale
   note: Gale. Authorized U-M users (+ guests in U-M Libraries)
   link: https://link.gale.com/apps/sas?u=umuser
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188933333106381':
 - collection_name: OverDrive Ebooks and Audiobooks
   interface_name: OverDrive
   note: OverDrive. 1 concurrent user limit. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.overdrive.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188948282406381':
 - collection_name: AccessScience
   interface_name: McGraw-Hill Companies, Inc.
   note: McGraw-Hill Companies, Inc. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.accessscience.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188950670806381':
 - collection_name: De Gruyter Gorgias Press Complete eBook-Package 2023
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188950670906381':
 - collection_name: De Gruyter Gorgias Press Complete eBook-Package 2024
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
-'99188951572806381':
-- collection_name: 'Wiley Digital Archives: Royal College of Physicians Part II'
-  interface_name: Wiley Online Library
-  note: Wiley Online Library. Access to the Authorized U-M users (+ guests in U-M Libraries)
-  link: https://app.wileydigitalarchives.com/rcp
-  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188996966706381':
 - collection_name: East View World News Connection
   interface_name: East View
   note: East View. Authorized U-M users (+ guests in U-M Libraries)
   link: https://wnc.eastview.com/wnc/news
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188996552606381':
 - collection_name: 'European Views of the Americas: 1493 to 1750'
   interface_name: EBSCOhost
   note: EBSCOhost. Open access for all users.
   link: http://www.europeanamericana.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188996533306381':
 - collection_name: English Language Learner Reference Center
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=elr
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188996604206381':
 - collection_name: De Gruyter University of Washington Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188996604306381':
 - collection_name: De Gruyter University Press of Colorado Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188996604706381':
 - collection_name: De Gruyter Amsterdam University Press Complete eBook-Package 2025
   interface_name: Walter De Gruyter Publishing
   note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
   link: https://www.degruyterbrill.com
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188997009906381':
 - collection_name: Global Health Archive
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: http://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=gha
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99188997010006381':
 - collection_name: Pascal-Francis
   interface_name: INIST-CNRS - Institut de l'Information Scientifique et Technique du CNRS
   note: INIST-CNRS - Institut de l'Information Scientifique et Technique du CNRS. Open access for all users.
   link: https://pascal-francis.inist.fr/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189002941906381':
 - collection_name: Dynamic Health
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&groupid=main&custid=s1221850&profile=dhe
   status: Available
+  campuses:
+  - ann_arbor
+  institution_codes:
+  - MIU
 '99189004436506381':
 - collection_name: Documenting White Supremacy and its Opponents in the 1920s
   interface_name: JSTOR
   note: JSTOR.
   link: https://dwso.revealdigital.org/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189004439306381':
 - collection_name: Rock's Backpages
   interface_name: Rock''s Backpages
   note: Rock''s Backpages. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.rocksbackpages.com/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189004441806381':
 - collection_name: Frescobaldi Thematic Catalogue Online (FTCO)
   interface_name: Duke University Press
   note: Duke University Press.
   link: http://frescobaldi.music.duke.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189009251206381':
 - collection_name: 'South Asia Commons: History and Culture'
   interface_name: Coherent Digital
   note: Coherent Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://southasiacommons.net/modules/history-and-culture
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189009251306381':
 - collection_name: 'South Asia Commons: South Asia Archive'
   interface_name: Coherent Digital
   note: Coherent Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://southasiacommons.net/modules/south-asia-archive
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189010247506381':
 - collection_name: Sources Chrétiennes Online
   interface_name: BREPOLIS
   note: BREPOLIS. Authorized U-M users (+ guests in U-M Libraries)
   link: http://apps.brepolis.net/ltool/entrance.aspx?w=34
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189011847806381':
 - collection_name: 'Policy Commons: North American City Reports'
   interface_name: Coherent Digital
   note: Coherent Digital. Authorized U-M users (+ guests in U-M Libraries)
   link: https://policycommons.net/modules/north-american-city-reports
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99188996966906381':
 - collection_name: 'Iter: Bibliography'
   interface_name: EBSCOhost
   note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
   link: https://search.ebscohost.com/login.aspx?authtype=ip,uid&profile=ehost&defaultdb=itb&groupid=main
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189013485006381':
 - collection_name: Bibliography of Linguistic Literature - Bibliographie Linguistischer Literatur
   interface_name: semantics Kommunikationsmanagement GmbH.
   note: semantics Kommunikationsmanagement GmbH. Authorized U-M users (+ guests in U-M Libraries)
   link: http://www.blldb-online.de
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189013494006381':
 - collection_name: Current Index to Statistics
   interface_name: American Statistical Association
   note: American Statistical Association. Authorized U-M users (+ guests in U-M Libraries)
   link: https://mathscinet.ams.org/cis
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '990033089410106381':
 - collection_name: Documenting the American South (DocSouth)
   interface_name: UNC University Libraries
   note: UNC University Libraries. Open access for all users.
   link: https://docsouth.unc.edu/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
 '99189015069006381':
 - collection_name: Modernist Journals Project
   interface_name: Brown University
   note: Brown University. Open access for all users.
   link: https://modjourn.org/journal/
   status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018199306381':
+- collection_name: EBSCOhost APA PsycEXTRA
+  interface_name: EBSCOhost
+  note: EBSCOhost. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://research.ebsco.com/c/mqk2bj?db=pxh
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018276106381':
+- collection_name: Times-Picayune
+  interface_name: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://infoweb.newsbank.com/apps/news/browse-multi?t=favorite%253A1223BCE5%2521Times-Picayune+Historical+and+Current+Collection&p=AWNB&f=advanced
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018276206381':
+- collection_name: Kansas City Star
+  interface_name: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://infoweb.newsbank.com/apps/news/browse-multi?t=favorite%253A1126152C%2521Kansas+City+Star+Historical+and+Current+Collection&p=WORLDNEWS&f=advanced
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018279906381':
+- collection_name: NewsBank Acceda Noticias
+  interface_name: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
+  link: http://infoweb.newsbank.com/?db=
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018280406381':
+- collection_name: Oklahoman
+  interface_name: Newsbank, Inc.
+  note: Newsbank, Inc. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://infoweb.newsbank.com/apps/news/browse-multi?t=favorite%253A18E8D497%2521Oklahoman+Historical+and+Current+Collection&p=WORLDNEWS&f=advanced
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018287606381':
+- collection_name: East View Global Press Archive Area Studies Initiative 2025
+  interface_name: East View
+  note: East View. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://gpa.eastview.com/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189018287806381':
+- collection_name: East View Global Press Archive Area Studies Initiative 2024
+  interface_name: East View
+  note: East View. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://gpa.eastview.com/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019289006381':
+- collection_name: 'The Nineteenth Century Stage: Industry, Performance and Celebrity'
+  interface_name: AM (Adam Matthew)
+  note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
+  link: https://www.nineteenthcenturystage.amdigital.co.uk/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019289306381':
+- collection_name: 'China on Film: Twentieth Century Sources from the British Film Institute'
+  interface_name: AM (Adam Matthew)
+  note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
+  link: https://www.chinaonfilm.amdigital.co.uk/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019289506381':
+- collection_name: Apartheid South Africa, 1989-1994
+  interface_name: AM (Adam Matthew)
+  note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
+  link: https://www.apartheidsouthafrica.amdigital.co.uk/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019301506381':
+- collection_name: 'Cuban Culture and Cultural Relations, 1959, The Vertical Archive of the Casa de las Américas, Part 4 : Music'
+  interface_name: Brillonline
+  note: Brillonline. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://primarysources.brillonline.com/browse/cuban-culture-and-cultural-relations-part-4
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019301606381':
+- collection_name: 'Cuban Culture and Cultural Relations, 1959-, Part 3: Theater'
+  interface_name: Brill
+  note: Brill. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://primarysources.brillonline.com/browse/cuban-culture-and-cultural-relations-part-3
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019301706381':
+- collection_name: 'Cuban Culture and Cultural Relations, 1959-, Part 2: Writers'
+  interface_name: Brill
+  note: Brill. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://primarysources.brillonline.com/browse/cuban-culture-and-cultural-relations-part-2
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189019301806381':
+- collection_name: 'Cuban Culture and Cultural Relations, 1959-The Vertical Archive of the Casa de las Américas, Part 1: “Casa y Cultura”'
+  interface_name: Brill
+  note: Brill. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://primarysources.brillonline.com/browse/cuban-culture-and-cultural-relations
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189025277806381':
+- collection_name: 'American Committee on Africa Module II: Anti-Apartheid Movements and Democracy'
+  interface_name: AM (Adam Matthew)
+  note: AM (Adam Matthew) Authorized U-M users (+ guests in U-M Libraries)
+  link: https://www.americancommitteeonafrica.amdigital.co.uk
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189027296106381':
+- collection_name: De Gruyter Hong Kong University Press Complete eBook Package 2025
+  interface_name: Walter De Gruyter Publishing
+  note: Walter De Gruyter Publishing. Authorized U-M users (+ guests in U-M Libraries)
+  link: https://www.degruyterbrill.com/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189027300406381':
+- collection_name: Air & Space and Smithsonian Magazine 2011-Present
+  interface_name: Gale
+  note: Gale.
+  link: https://link.gale.com/apps/smit?u=umuser
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC
+'99189030496806381':
+- collection_name: EBSCOHOST Dynamic Health CDS and SKILLS
+  interface_name: EBSCOhost
+  note: EBSCOhost.
+  link: https://www.dynahealth.com/
+  status: Available
+  campuses:
+  - ann_arbor
+  - flint
+  institution_codes:
+  - MIU
+  - MIFLIC

--- a/umich_catalog_indexing/spec/jobs/translation_map_generator/electronic_collections_spec.rb
+++ b/umich_catalog_indexing/spec/jobs/translation_map_generator/electronic_collections_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::List do
        "Electronic Collection Interface Name" => "INTERFACE",
        "Electronic Collection Public Name (override)" => "OVERRIDE_NAME",
        "Electronic Collection Public Name" => "NAME",
-       "Electronic Collection Public Note" => "PUBLIC_NOTE"}
+       "Electronic Collection Public Note" => "PUBLIC_NOTE",
+       "Available For Group" => "Ann Arbor; Flint"}
     ]
   end
   subject do
@@ -28,7 +29,9 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::List do
           "interface_name" => "OVERRIDE_INTERFACE",
           "note" => "OVERRIDE_INTERFACE. PUBLIC_NOTE. AUTH_NOTE.",
           "link" => "OVERRIDE_URL",
-          "status" => "Available"
+          "status" => "Available",
+          "campuses" => ["ann_arbor", "flint"],
+          "institution_codes" => ["MIU", "MIFLIC"]
         }
       ]
     }
@@ -58,7 +61,8 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::Item do
       "Electronic Collection Interface Name" => "INTERFACE",
       "Electronic Collection Public Name (override)" => "OVERRIDE_NAME",
       "Electronic Collection Public Name" => "NAME",
-      "Electronic Collection Public Note" => "PUBLIC_NOTE"
+      "Electronic Collection Public Note" => "PUBLIC_NOTE",
+      "Available For Group" => "Ann Arbor; Flint"
     }
   end
   subject do
@@ -125,6 +129,40 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::Item do
       expect(subject.interface_name).to eq("")
     end
   end
+  context "campuses" do
+    it "splits into array on the semicolon; lc and snake case" do
+      expect(subject.campuses).to contain_exactly("ann_arbor", "flint")
+    end
+    it "returns both when there's nil" do
+      @item["Available For Group"] = nil
+      expect(subject.campuses).to contain_exactly("ann_arbor", "flint")
+    end
+    it "returns flint when only flint" do
+      @item["Available For Group"] = "Flint"
+      expect(subject.campuses).to contain_exactly("flint")
+    end
+    it "returns ann_arbor when only Ann Arbor" do
+      @item["Available For Group"] = "Ann Arbor"
+      expect(subject.campuses).to contain_exactly("ann_arbor")
+    end
+  end
+  context "institution_codes" do
+    it "splits into array on the semicolon; MIU MIFLIC" do
+      expect(subject.institution_codes).to contain_exactly("MIU", "MIFLIC")
+    end
+    it "returns both when there's nil" do
+      @item["Available For Group"] = nil
+      expect(subject.institution_codes).to contain_exactly("MIU", "MIFLIC")
+    end
+    it "returns flint when only flint" do
+      @item["Available For Group"] = "Flint"
+      expect(subject.institution_codes).to contain_exactly("MIFLIC")
+    end
+    it "returns ann_arbor when only Ann Arbor" do
+      @item["Available For Group"] = "Ann Arbor"
+      expect(subject.institution_codes).to contain_exactly("MIU")
+    end
+  end
   context "#note" do
     it "returns the Interface name. Public Note. Authentication Note. when they all exist" do
       s = subject
@@ -162,7 +200,9 @@ RSpec.describe Jobs::TranslationMapGenerator::ElectronicCollections::Item do
         "interface_name" => "OVERRIDE_INTERFACE",
         "note" => "OVERRIDE_INTERFACE. PUBLIC_NOTE. AUTH_NOTE.",
         "link" => "OVERRIDE_URL",
-        "status" => "Available"
+        "status" => "Available",
+        "campuses" => ["ann_arbor", "flint"],
+        "institution_codes" => ["MIU", "MIFLIC"]
       })
     end
   end


### PR DESCRIPTION
This uses the same logic for Electronic Collections as `ElectronicHoldings`. When a single campus is present only add that. When none or both are present, add both. 