### PR TITLE
comments out logging about subject subfields

### DIFF
--- a/umich_catalog_indexing/lib/common/subjects/lc_subject.rb
+++ b/umich_catalog_indexing/lib/common/subjects/lc_subject.rb
@@ -44,10 +44,10 @@ module Common
       def self.lcsh_subject_field_2?(field)
         return true if field["2"].nil?
         if field["2"].include?("lcsh") || field["2"].include?("naf")
-          S.logger.warn("LCSH_UNNECESSARY_SUBFIELD_2", field: field.to_s)
+          # S.logger.warn("LCSH_UNNECESSARY_SUBFIELD_2", field: field.to_s)
           return true
         end
-        S.logger.warn("LCSH_SUBFIELD_2_NOT_LCSH", field: field.to_s)
+        # S.logger.warn("LCSH_SUBFIELD_2_NOT_LCSH", field: field.to_s)
         false
       end
 


### PR DESCRIPTION
This was pretty loud last time and most of these are for community zone records. Turning this off until we can get more specific info.