### PR TITLE
LIBSEARCH-1171 adds childrens literature ad based on audience

### DIFF
--- a/umich_catalog_indexing/indexers/callnumbers.rb
+++ b/umich_catalog_indexing/indexers/callnumbers.rb
@@ -141,13 +141,42 @@ end
 ### High Level Browse ###
 require "high_level_browse"
 
+def age_or_grade_level_at_or_below?(value, highest_level)
+  # between is inclusive
+  value.to_i.between?(1, highest_level)
+end
+
+def target_audience?(rec)
+  rec.fields("521").any? do |ta|
+    case ta.indicator1
+    when "0" # reading grade
+      age_or_grade_level_at_or_below?(ta["a"], 12)
+    when "1" # interest age
+      age_or_grade_level_at_or_below?(ta["a"], 17)
+    when "2" # interest grade
+      age_or_grade_level_at_or_below?(ta["a"], 12)
+    else
+      false
+    end
+  end
+end
+
+def childrens_literature(rec)
+  if ["a", "b", "c", "d", "j"].include?(rec["008"].value[22]) || target_audience?(rec)
+    [["Humanities", "Children's Literature"]]
+  else
+    []
+  end
+end
+
 hlb = HighLevelBrowse.load(dir: S.hlb_path)
 to_field "hlb3Delimited", extract_marc("050ab:082a:090ab:099a:086a:086z:852|0*|hij") do |rec, acc, context|
   acc.select! { |cn| looks_like_lc?(cn) }
   acc.map! { |c| hlb[c] }
+  acc << childrens_literature(rec)
   acc.compact!
-  acc.uniq!
   acc.flatten!(1)
+  acc.uniq!
 
   # Get the individual conmponents and stash them
   components = acc.flatten.to_a.uniq

--- a/umich_catalog_indexing/spec/indexers/callnumbers_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/callnumbers_spec.rb
@@ -1,10 +1,10 @@
 require "traject"
-describe "callnumber_browse" do
+describe "callnumbers" do
   let(:hurdy_gurdy) do
     get_record("./spec/fixtures/hurdy_gurdy.xml")
   end
-  let(:indexer) do
-    Traject::Indexer.new do
+  before(:all) do
+    @indexer = Traject::Indexer.new do
       load_config_file("./spec/support/traject_settings.rb")
       load_config_file("./indexers/common.rb")
       load_config_file("./indexers/callnumbers.rb")
@@ -14,35 +14,106 @@ describe "callnumber_browse" do
     @record = nil
   end
   subject do
-    indexer.process_record(@record).output_hash
+    @indexer.process_record(@record).output_hash
   end
-  it "adds a callnumber to callnumber_browse field" do
-    @record = hurdy_gurdy
-    expect(subject["callnumber_browse"]).to eq(["ML760 .P18"])
+  context "callnumber_browse" do
+    it "adds a callnumber to callnumber_browse field" do
+      @record = hurdy_gurdy
+      expect(subject["callnumber_browse"]).to eq(["ML760 .P18"])
+    end
+    it "does not include single and double letter callnumbers" do
+      # N and ZZ are invalid callnumbers. They break call number browse.
+      @record = hurdy_gurdy
+      @record.append(MARC::DataField.new("852", "0", "0",
+        ["h", "ZZ"]))
+      @record.append(MARC::DataField.new("852", "0", "0",
+        ["h", "N"]))
+      @record.append(MARC::DataField.new("852", "0", "0",
+        ["h", "ML760 .P18 2025"]))
+      expect(subject["callnumber_browse"]).to eq(["ML760 .P18", "ML760 .P18 2025"])
+    end
+    it "does not include any callnumbers when the item type is j" do
+      @record = hurdy_gurdy
+      @record.leader[6] = "j"
+      expect(subject["callnumber_browse"]).to be_nil
+    end
+    it "does not include call numbers with W or w" do
+      @record = hurdy_gurdy
+      @record.fields.delete_if { |x| x.tag == "852" }
+      @record.append(MARC::DataField.new("050", "", "4",
+        ["a", "WB 925"], ["b", ".H236 2006"]))
+      @record.append(MARC::DataField.new("050", "", "4",
+        ["a", "wb 925"], ["b", ".H236 2006"]))
+      expect(subject["callnumber_browse"]).to be_nil
+    end
   end
-  it "does not include single and double letter callnumbers" do
-    # N and ZZ are invalid callnumbers. They break call number browse.
-    @record = hurdy_gurdy
-    @record.append(MARC::DataField.new("852", "0", "0",
-      ["h", "ZZ"]))
-    @record.append(MARC::DataField.new("852", "0", "0",
-      ["h", "N"]))
-    @record.append(MARC::DataField.new("852", "0", "0",
-      ["h", "ML760 .P18 2025"]))
-    expect(subject["callnumber_browse"]).to eq(["ML760 .P18", "ML760 .P18 2025"])
-  end
-  it "does not include any callnumbers when the item type is j" do
-    @record = hurdy_gurdy
-    @record.leader[6] = "j"
-    expect(subject["callnumber_browse"]).to be_nil
-  end
-  it "does not include call numbers with W or w" do
-    @record = hurdy_gurdy
-    @record.fields.delete_if { |x| x.tag == "852" }
-    @record.append(MARC::DataField.new("050", "", "4",
-      ["a", "WB 925"], ["b", ".H236 2006"]))
-    @record.append(MARC::DataField.new("050", "", "4",
-      ["a", "wb 925"], ["b", ".H236 2006"]))
-    expect(subject["callnumber_browse"]).to be_nil
+  context "hlb3Delimited" do
+    let(:reading_grade) { MARC::DataField.new("521", "0", "", ["a", "12.8"]) }
+    let(:interest_age) { MARC::DataField.new("521", "1", "", ["a", "008-012"]) }
+    let(:interest_grade) { MARC::DataField.new("521", "2", "", ["a", "12 & up"]) }
+    it "does not include children's literature when there's no need to" do
+      @record = hurdy_gurdy
+      expect(subject["hlb3Delimited"]).not_to include("Humanities | Children's Literature")
+    end
+    it "includes children's literature when 008 has 22 a" do
+      # a, b, c, d, or j
+      @record = hurdy_gurdy
+      @record["008"].value[22] = "a"
+      expect(subject["hlb3Delimited"]).to include("Humanities | Children's Literature")
+    end
+    it "includes reading grade <= 12" do
+      @record = hurdy_gurdy
+      @record.append(reading_grade)
+      expect(subject["hlb3Delimited"]).to include("Humanities | Children's Literature")
+    end
+    it "does not include reading grade > 12" do
+      @record = hurdy_gurdy
+      @record.append(reading_grade)
+      @record["521"].subfields.first.value = "15.1"
+      expect(subject["hlb3Delimited"]).not_to include("Humanities | Children's Literature")
+    end
+    it "includes interest age <= 18" do
+      @record = hurdy_gurdy
+      @record.append(interest_age)
+      expect(subject["hlb3Delimited"]).to include("Humanities | Children's Literature")
+    end
+    it "does not include interest age > 18" do
+      @record = hurdy_gurdy
+      @record.append(interest_age)
+      @record["521"].subfields.first.value = "18 and up"
+      expect(subject["hlb3Delimited"]).not_to include("Humanities | Children's Literature")
+    end
+    it "includes interest grade <= 12" do
+      @record = hurdy_gurdy
+      @record.append(interest_grade)
+      expect(subject["hlb3Delimited"]).to include("Humanities | Children's Literature")
+    end
+    it "does not include interest grade greater than 12" do
+      @record = hurdy_gurdy
+      @record.append(interest_grade)
+      @record["521"].subfields.first.value = "13+"
+      expect(subject["hlb3Delimited"]).not_to include("Humanities | Children's Literature")
+    end
+    it "handles multiple 521s where only one is true" do
+      @record = hurdy_gurdy
+      @record.append(interest_grade)
+      @record.append(reading_grade)
+      @record.append(interest_age)
+      fields = @record.fields("521")
+      fields.first.subfields.first.value = "13+"
+      fields.last.subfields.first.value = "18 and up"
+      expect(subject["hlb3Delimited"]).to include("Humanities | Children's Literature")
+    end
+    it "handles multiple 521s where only none are true" do
+      @record = hurdy_gurdy
+      @record.append(reading_grade)
+      @record.append(interest_age)
+      @record.append(interest_grade)
+      fields = @record.fields("521")
+      fields[0].subfields.first.value = "13.5"
+      fields[1].subfields.first.value = "18 and up"
+      fields[2].subfields.first.value = "13+"
+      expect(subject["hlb3Delimited"]).not_to include("Humanities | Children's Literature")
+    end
   end
 end


### PR DESCRIPTION
Addresses [LIBSEARCH-1171](https://mlit.atlassian.net/browse/LIBSEARCH-1171)

In addition to call number, Children's literature can be identified by $008 character 22 and by the Interest age and grade levels indicated in $521 