### PR TITLE
remove old endpoints

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -1,13 +1,7 @@
-from typing import Annotated
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
-from prometheus_client import Histogram
 
-from api import schemas
-from api.solr_client import NotFoundError
-from api.record import record_for
-from api.results import get_results
 from .routers import catalog
 
 app = FastAPI(
@@ -17,57 +11,3 @@ app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.include_router(catalog.router)
 
 Instrumentator().instrument(app).expose(app)
-
-RECORD_HISTOGRAM = Histogram(
-    "catalog_api_record_request_duration_seconds",
-    "Length of api request for a catalog record",
-)
-
-
-@app.get(
-    "/records/{id}",
-    responses={
-        404: {
-            "description": "Bad request: The record was not found",
-            "model": schemas.Response404,
-        }
-    },
-    response_model_exclude_none=True,
-)
-@RECORD_HISTOGRAM.time()
-def get_record(id: str) -> schemas.Record:
-    """
-    Gets a record from catalog solr. The record is fetched by the solr id, which
-    is the mms_id for an Alma record or a htid with a 11 prefix for a HathiTrust
-    record
-    """
-    try:
-        result = record_for(id)
-        return result
-    except NotFoundError:
-        raise HTTPException(status_code=404, detail="Item not found")
-
-
-@app.get("/search", response_model_exclude_none=True)
-def get_search_results(
-    query: str = "",
-    offset: int = 0,
-    limit: int = 10,
-    filters: Annotated[list[str], Query()] = [],
-    ht_search_only: bool = False,
-    sort: schemas.Sort = schemas.Sort.relevance,
-) -> schemas.Results:
-    """
-    Does a search in catalog solr
-    """
-    results = get_results(
-        {
-            "query": query,
-            "offset": offset,
-            "limit": limit,
-            "filters": filters,
-            "ht_search_only": ht_search_only,
-            "sort": sort,
-        }
-    )
-    return results

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -30,7 +30,7 @@ def test_get_record(client, valid_mms_id, solr_bib):
     with open("tests/fixtures/land_birds.json") as data:
         expected = json.load(data)
 
-    response = client.get(f"/records/{valid_mms_id}")
+    response = client.get(f"/catalog/records/{valid_mms_id}")
     assert response.status_code == 200
     subject = response.json()
     for field in expected:


### PR DESCRIPTION
`search.application` is using `catalog/records/<id>` and `catalog/search` instead of `/records` and `/search` so it's safe to get rid of those.