### PR TITLE
fix call number browse problems

### DIFF
--- a/umich_catalog_indexing/indexers/callnumbers.rb
+++ b/umich_catalog_indexing/indexers/callnumbers.rb
@@ -78,8 +78,8 @@ to_field "callnumber_browse" do |rec, acc, context|
     # generate "id" fields for these which make browsing these callnumbers fail.
     # Also these are invalid LC call numbers.
     acc.reject! { |x| x =~ /^\w{1,2}$/ }
-    # W is not a valid LC call number classification
-    acc.reject! { |x| x =~ /^[wW]/ }
+    # W is not a valid LC call number classification (with or without a leading period)
+    acc.reject! { |x| x =~ /^\.?[wW]/ }
   end
 end
 

--- a/umich_catalog_indexing/indexers/callnumbers.rb
+++ b/umich_catalog_indexing/indexers/callnumbers.rb
@@ -64,7 +64,7 @@ end
 # callnumber_browse
 
 to_field "callnumber_browse" do |rec, acc, context|
-  if rec.leader[6] != "j"
+  if !["j", "g"].include?(rec.leader[6])
     cns = context.clipboard["callnumbers"]
     cns_852 = cns[:lc_852].concat(cns[:dewey_852])
 

--- a/umich_catalog_indexing/spec/indexers/callnumbers_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/callnumbers_spec.rb
@@ -37,6 +37,11 @@ describe "callnumbers" do
       @record.leader[6] = "j"
       expect(subject["callnumber_browse"]).to be_nil
     end
+    it "does not include any callnumbers when the item type g" do
+      @record = hurdy_gurdy
+      @record.leader[6] = "g"
+      expect(subject["callnumber_browse"]).to be_nil
+    end
     it "does not include call numbers with W or w" do
       @record = hurdy_gurdy
       @record.fields.delete_if { |x| x.tag == "852" }

--- a/umich_catalog_indexing/spec/indexers/callnumbers_spec.rb
+++ b/umich_catalog_indexing/spec/indexers/callnumbers_spec.rb
@@ -42,13 +42,15 @@ describe "callnumbers" do
       @record.leader[6] = "g"
       expect(subject["callnumber_browse"]).to be_nil
     end
-    it "does not include call numbers with W or w" do
+    it "does not include call numbers with W or w or a leading period" do
       @record = hurdy_gurdy
       @record.fields.delete_if { |x| x.tag == "852" }
       @record.append(MARC::DataField.new("050", "", "4",
         ["a", "WB 925"], ["b", ".H236 2006"]))
       @record.append(MARC::DataField.new("050", "", "4",
         ["a", "wb 925"], ["b", ".H236 2006"]))
+      @record.append(MARC::DataField.new("050", "", "4",
+        ["a", ".wb 925"], ["b", ".H236 2006"]))
       expect(subject["callnumber_browse"]).to be_nil
     end
   end


### PR DESCRIPTION
This PR 
* removes items with leader 6 == g from call number browse. (These are videos and their "call numbers" are misleading.)
* `.w` call numbers should be excluded from call number browse (leading periods are not valid)