### PR TITLE
remove local call number 099 for high level browse

### DIFF
--- a/umich_catalog_indexing/indexers/callnumbers.rb
+++ b/umich_catalog_indexing/indexers/callnumbers.rb
@@ -170,7 +170,7 @@ def childrens_literature(rec)
 end
 
 hlb = HighLevelBrowse.load(dir: S.hlb_path)
-to_field "hlb3Delimited", extract_marc("050ab:082a:090ab:099a:086a:086z:852|0*|hij") do |rec, acc, context|
+to_field "hlb3Delimited", extract_marc("050ab:082a:090ab:086a:086z:852|0*|hij") do |rec, acc, context|
   acc.select! { |cn| looks_like_lc?(cn) }
   acc.map! { |c| hlb[c] }
   acc << childrens_literature(rec)


### PR DESCRIPTION
Because we included 099 as a field where call numbers could be we were getting spurious academic disciplines. This PR removes 099 from consideration.