### PR TITLE
Update catalog contributors field

### DIFF
--- a/api/api/record.py
+++ b/api/api/record.py
@@ -276,26 +276,54 @@ class MARC:
 
     @property
     def contributors(self):
+
         def is_not_a_title(field: pymarc.Field) -> bool:
             return not field.get_subfields("t") and field.indicator2 != "2"
 
-        display_sfs = "abcdegjnqu4"
+        def has_valid_4(field: pymarc.Field) -> bool:
+            return not (
+                field.get_subfields("e")
+                or any(sf.startswith("http") for sf in field.get_subfields("4"))
+            )
+
+        def show_4(field: pymarc.Field) -> bool:
+            return has_valid_4(field) and is_not_a_title(field)
+
+        def do_not_show_4(field: pymarc.Field) -> bool:
+            return not has_valid_4(field) and is_not_a_title(field)
+
+        display_sfs = "abcdegjnqu"
+        display_sfs_with_4 = display_sfs + "4"
         search_sfs = "abcdgjnqu"
         search2_sfs = "acdegnqu"
         rulesets = (
             FieldRuleset(
                 tags=["700", "710"],
                 search=[{"subfields": search_sfs, "field": "author"}],
+                text_sfs=display_sfs_with_4,
+                browse_sfs=search_sfs,
+                filter=show_4,
+            ),
+            FieldRuleset(
+                tags=["711"],
+                search=[{"subfields": search2_sfs, "field": "author"}],
+                text_sfs=display_sfs_with_4,
+                browse_sfs=search2_sfs,
+                filter=show_4,
+            ),
+            FieldRuleset(
+                tags=["700", "710"],
+                search=[{"subfields": search_sfs, "field": "author"}],
                 text_sfs=display_sfs,
                 browse_sfs=search_sfs,
-                filter=is_not_a_title,
+                filter=do_not_show_4,
             ),
             FieldRuleset(
                 tags=["711"],
                 search=[{"subfields": search2_sfs, "field": "author"}],
                 text_sfs=display_sfs,
                 browse_sfs=search2_sfs,
-                filter=is_not_a_title,
+                filter=do_not_show_4,
             ),
         )
 

--- a/api/api/record.py
+++ b/api/api/record.py
@@ -276,18 +276,30 @@ class MARC:
 
     @property
     def contributors(self):
-        search_sfs = "abcdgjkqu"
-        ruleset = FieldRuleset(
-            tags=["700", "710", "711"],
-            search=[{"subfields": search_sfs, "field": "author"}],
-            text_sfs="abcdefgjklnpqu4",
-            browse_sfs=search_sfs,
-            filter=lambda field: (
-                not field.get_subfields("t") and field.indicator2 != "2"
+        def is_not_a_title(field: pymarc.Field) -> bool:
+            return not field.get_subfields("t") and field.indicator2 != "2"
+
+        display_sfs = "abcdegjnqu4"
+        search_sfs = "abcdgjnqu"
+        search2_sfs = "acdegnqu"
+        rulesets = (
+            FieldRuleset(
+                tags=["700", "710"],
+                search=[{"subfields": search_sfs, "field": "author"}],
+                text_sfs=display_sfs,
+                browse_sfs=search_sfs,
+                filter=is_not_a_title,
+            ),
+            FieldRuleset(
+                tags=["711"],
+                search=[{"subfields": search2_sfs, "field": "author"}],
+                text_sfs=display_sfs,
+                browse_sfs=search2_sfs,
+                filter=is_not_a_title,
             ),
         )
 
-        return self.processor.generate_paired_fields(tuple([ruleset]))
+        return self.processor.generate_paired_fields(tuple(rulesets))
 
     @property
     def created(self):

--- a/api/tests/test_record.py
+++ b/api/tests/test_record.py
@@ -541,7 +541,8 @@ class TestMARC:
     # contributors #
     ################
     @pytest.mark.parametrize("tag", ["700", "710"])
-    def test_contributors_with_indicator_2_not_2_and_no_t(self, tag):
+    def test_contributors_with_indicator_2_not_2_and_no_t_and_e_present(self, tag):
+        # this should not show 4
         sfs = string.ascii_lowercase.replace("t", "") + "4"
         record = create_record_with_paired_field(tag=tag, subfields=sfs)
 
@@ -549,7 +550,49 @@ class TestMARC:
         expected = self.expected_paired_field(
             tag=tag,
             elements={
-                "text": "a b c d e g j n q u 4",
+                "text": "a b c d e g j n q u",
+                "search": [{"field": "author", "value": "a b c d g j n q u"}],
+                "browse": "a b c d g j n q u",
+            },
+        )
+
+        assert serialize(subject.contributors) == expected
+
+    @pytest.mark.parametrize("tag", ["700", "710"])
+    def test_contributors_with_indicator_2_not_2_and_no_t_and_e_not_present(self, tag):
+        # this should show 4 (and not e because it is not there)
+        sfs = string.ascii_lowercase.replace("t", "") + "4"
+        sfs = sfs.replace("e", "")
+        record = create_record_with_paired_field(tag=tag, subfields=sfs)
+
+        subject = MARC(record)
+        expected = self.expected_paired_field(
+            tag=tag,
+            elements={
+                "text": "a b c d g j n q u 4",
+                "search": [{"field": "author", "value": "a b c d g j n q u"}],
+                "browse": "a b c d g j n q u",
+            },
+        )
+
+        assert serialize(subject.contributors) == expected
+
+    @pytest.mark.parametrize("tag", ["700", "710"])
+    def test_contributors_with_indicator_2_not_2_and_no_t_and_e_not_present_4_starts_with_http(
+        self, tag
+    ):
+        # this should show 4 (and not e because it is not there)
+        sfs = string.ascii_lowercase.replace("t", "") + "4"
+        sfs = sfs.replace("e", "")
+        record = create_record_with_paired_field(tag=tag, subfields=sfs)
+        record[tag]["4"] = "http://some-website"
+        record["880"]["4"] = "http://some-website"
+
+        subject = MARC(record)
+        expected = self.expected_paired_field(
+            tag=tag,
+            elements={
+                "text": "a b c d g j n q u",
                 "search": [{"field": "author", "value": "a b c d g j n q u"}],
                 "browse": "a b c d g j n q u",
             },
@@ -558,7 +601,8 @@ class TestMARC:
         assert serialize(subject.contributors) == expected
 
     @pytest.mark.parametrize("tag", ["711"])
-    def test_contributors_711_with_indicator_2_not_2_and_no_t(self, tag):
+    def test_contributors_711_with_indicator_2_not_2_and_no_t_and_e_present(self, tag):
+        # this should not show 4
         sfs = string.ascii_lowercase.replace("t", "") + "4"
         record = create_record_with_paired_field(tag=tag, subfields=sfs)
 
@@ -566,9 +610,53 @@ class TestMARC:
         expected = self.expected_paired_field(
             tag=tag,
             elements={
-                "text": "a b c d e g j n q u 4",
+                "text": "a b c d e g j n q u",
                 "search": [{"field": "author", "value": "a c d e g n q u"}],
                 "browse": "a c d e g n q u",
+            },
+        )
+
+        assert serialize(subject.contributors) == expected
+
+    @pytest.mark.parametrize("tag", ["711"])
+    def test_contributors_711_with_indicator_2_not_2_and_no_t_and_e_not_present(
+        self, tag
+    ):
+        # this should show 4 (but not e because it's not there)
+        sfs = string.ascii_lowercase.replace("t", "") + "4"
+        sfs = sfs.replace("e", "")
+        record = create_record_with_paired_field(tag=tag, subfields=sfs)
+
+        subject = MARC(record)
+        expected = self.expected_paired_field(
+            tag=tag,
+            elements={
+                "text": "a b c d g j n q u 4",
+                "search": [{"field": "author", "value": "a c d g n q u"}],
+                "browse": "a c d g n q u",
+            },
+        )
+
+        assert serialize(subject.contributors) == expected
+
+    @pytest.mark.parametrize("tag", ["711"])
+    def test_contributors_711_with_indicator_2_not_2_and_no_t_and_e_not_present_4_has_http(
+        self, tag
+    ):
+        # this should show 4 (but not e because it's not there)
+        sfs = string.ascii_lowercase.replace("t", "") + "4"
+        sfs = sfs.replace("e", "")
+        record = create_record_with_paired_field(tag=tag, subfields=sfs)
+        record["711"]["4"] = "http://some-website"
+        record["880"]["4"] = "http://some-website"
+
+        subject = MARC(record)
+        expected = self.expected_paired_field(
+            tag=tag,
+            elements={
+                "text": "a b c d g j n q u",
+                "search": [{"field": "author", "value": "a c d g n q u"}],
+                "browse": "a c d g n q u",
             },
         )
 

--- a/api/tests/test_record.py
+++ b/api/tests/test_record.py
@@ -540,7 +540,7 @@ class TestMARC:
     ################
     # contributors #
     ################
-    @pytest.mark.parametrize("tag", ["700", "710", "711"])
+    @pytest.mark.parametrize("tag", ["700", "710"])
     def test_contributors_with_indicator_2_not_2_and_no_t(self, tag):
         sfs = string.ascii_lowercase.replace("t", "") + "4"
         record = create_record_with_paired_field(tag=tag, subfields=sfs)
@@ -549,9 +549,26 @@ class TestMARC:
         expected = self.expected_paired_field(
             tag=tag,
             elements={
-                "text": "a b c d e f g j k l n p q u 4",
-                "search": [{"field": "author", "value": "a b c d g j k q u"}],
-                "browse": "a b c d g j k q u",
+                "text": "a b c d e g j n q u 4",
+                "search": [{"field": "author", "value": "a b c d g j n q u"}],
+                "browse": "a b c d g j n q u",
+            },
+        )
+
+        assert serialize(subject.contributors) == expected
+
+    @pytest.mark.parametrize("tag", ["711"])
+    def test_contributors_711_with_indicator_2_not_2_and_no_t(self, tag):
+        sfs = string.ascii_lowercase.replace("t", "") + "4"
+        record = create_record_with_paired_field(tag=tag, subfields=sfs)
+
+        subject = MARC(record)
+        expected = self.expected_paired_field(
+            tag=tag,
+            elements={
+                "text": "a b c d e g j n q u 4",
+                "search": [{"field": "author", "value": "a c d e g n q u"}],
+                "browse": "a c d e g n q u",
             },
         )
 


### PR DESCRIPTION
For catalog contributors, we don't want to display the $4 when there is an $e present nor when $4 starts with "http". We should also have a different set of subfields that's displayed. This is described in the metadata spreadsheet.
